### PR TITLE
only activate agent if r10k is executable on $PATH

### DIFF
--- a/files/agent/r10k.rb
+++ b/files/agent/r10k.rb
@@ -1,6 +1,18 @@
 module MCollective
   module Agent
     class R10k<RPC::Agent
+       activate_when do
+         #This helper only activate this agent for discovery and execution
+         #If r10k is found on $PATH.
+         # http://docs.puppetlabs.com/mcollective/simplerpc/agents.html#agent-activation
+         r10k_binary = `which r10k 2> /dev/null`
+         if r10k_binary == ""
+           #r10k not found on path.
+           false
+         else
+           true
+         end
+       end
        ['push',
         'pull',
         'status'].each do |act|


### PR DESCRIPTION
This commit makes the node on mcollective discoverable
for the agent r10k only if the r10k binary is available
and executable on $PATH.

This way the agent will only run on machines that have
r10k installed.

This helper activate_when  only activate
this agent for discovery and execution if
the r10k binary is found on $PATH.
http://docs.puppetlabs.com/mcollective/simplerpc/agents.html#agent-activation