### PR TITLE
[Deprecation] Remove purgedirs support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,9 +10,6 @@
 # * [*sources*]
 #   Hash containing data sources to be used by r10k to create dynamic Puppet
 #   environments. Default: {}
-# * [*purgedirs*]
-#   An Array of directory paths to purge of any subdirectories that do not
-#   correspond to a dynamic environment managed by r10k. Default: []
 # * [*manage_configfile_symlink*]
 #   Boolean to determine if a symlink to the r10k config file is to be managed.
 #   Default: false
@@ -32,10 +29,6 @@
 #        'basedir' => '/some/other/basedir'
 #      },
 #    },
-#    purgedirs => [
-#      "${::settings::confdir}/environments",
-#      '/some/other/basedir',
-#    ],
 #  }
 #
 # == Documentation
@@ -53,7 +46,6 @@ class r10k::config (
   $modulepath                = undef,
   $remote                    = '',
   $sources                   = 'UNSET',
-  $purgedirs                 = [],
   $puppetconf_path           = $r10k::params::puppetconf_path,
   $r10k_basedir              = $r10k::params::r10k_basedir,
   $manage_configfile_symlink = $r10k::params::manage_configfile_symlink,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,6 @@
 class r10k (
   $remote                    = $r10k::params::remote,
   $sources                   = $r10k::params::sources,
-  $purgedirs                 = $r10k::params::r10k_purgedirs,
   $cachedir                  = $r10k::params::r10k_cache_dir,
   $configfile                = $r10k::params::r10k_config_file,
   $version                   = $r10k::params::version,
@@ -46,7 +45,6 @@ class r10k (
     cachedir                  => $cachedir,
     configfile                => $configfile,
     sources                   => $sources,
-    purgedirs                 => $purgedirs,
     modulepath                => $modulepath,
     remote                    => $remote,
     manage_modulepath         => $manage_modulepath,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,6 @@ class r10k::params
   $r10k_config_file          = '/etc/r10k.yaml'
   $r10k_cache_dir            = '/var/cache/r10k'
   $r10k_basedir              = "${::settings::confdir}/environments"
-  $r10k_purgedirs            = $r10k_basedir
   $manage_configfile_symlink = false
   $configfile_symlink        = '/etc/r10k.yaml'
 

--- a/templates/r10k.yaml.erb
+++ b/templates/r10k.yaml.erb
@@ -8,8 +8,3 @@
 <% end -%>
 <% end -%>
 <% end %>
-<%# The Array boxing/flattening ensures we don't get bitten by bug #15813 -%>
-<% unless [@purgedirs].flatten.empty? -%>
-:purgedirs:
-<%= [@purgedirs].flatten.to_yaml.split("\n")[1..-1].join("\n") %>
-<% end -%>


### PR DESCRIPTION
As of R10K 1.0.0 the purgedirs functionality and configuration options
have been removed. This module continues to configure the no longer
acknowledged configuration options.

This commit removes support for the purgedirs configuration option.

Oh, also... It should be mentioned that R10K 1.x was released over a year ago now. Reasonably, nobody should be running pre 1.x anymore. 