### PR TITLE
support strict_variables = true

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class r10k::params
   $version                = '1.4.0'
   $manage_modulepath      = false
   $manage_ruby_dependency = 'declare'
-  $install_options        = undef
+  $install_options        = []
   $sources                = undef
 
   # r10k configuration


### PR DESCRIPTION
The package resource fails when passed undef and strict_variables = true.  An empty array has the same effect as undef, but succeeds with strict_variables.