### PR TITLE
105 updated webhook.ini.erb for ubuntu support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,7 +47,12 @@ class r10k::params
   $webhook_prefix_command     = '/bin/echo example'
   $webhook_enable_ssl         = true
   $webhook_use_mcollective    = true
-
+  if $::osfamily == Debian {
+    $functions_path     = '/lib/lsb/init-functions'
+    $start_pidfile_args = '--pidfile=$pidfile'
+  else
+    $functions_path     = '/etc/rc.d/init.d/functions'
+    $start_pidfile_args = '--pidfile $pidfile'
   if $::is_pe == true or $::is_pe == 'true' {
     # Puppet Enterprise specific settings
     $puppetconf_path = '/etc/puppetlabs/puppet'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,9 +50,11 @@ class r10k::params
   if $::osfamily == Debian {
     $functions_path     = '/lib/lsb/init-functions'
     $start_pidfile_args = '--pidfile=$pidfile'
-  else
+  }
+  else {
     $functions_path     = '/etc/rc.d/init.d/functions'
     $start_pidfile_args = '--pidfile $pidfile'
+  }
   if $::is_pe == true or $::is_pe == 'true' {
     # Puppet Enterprise specific settings
     $puppetconf_path = '/etc/puppetlabs/puppet'

--- a/templates/webhook.init.erb
+++ b/templates/webhook.init.erb
@@ -15,7 +15,7 @@ DAEMON_USER='<%= @user %>'
 RETVAL=0
 
 # Source function library.
-. /etc/rc.d/init.d/functions
+. <%= @functions_path %>
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 export PATH
@@ -23,7 +23,7 @@ export PATH
 start() {
     echo
     echo -n $"Starting webhook: "
-    daemon --user ${DAEMON_USER:?} --pidfile $pidfile $webhook
+    daemon --user ${DAEMON_USER:?} <%= @start_pidfile_args %> $webhook
     RETVAL=$?
     return $RETVAL
 }


### PR DESCRIPTION
Added 2 parameters to encapsulate the changes required for Ubuntu systems to launch the r10k daemon successfully. This is the modification I have running and testing in my environment, and while it's not a particularly clean solution, perhaps you'd want to integrate it to support Ubuntu masters until a large refactoring might be done.