### PR TITLE
Remove +x permissions from peadmin-cert.pem

### DIFF
--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -45,6 +45,7 @@ class r10k::webhook(
       ensure  => 'file',
       owner   => 'peadmin',
       group   => 'peadmin',
+      mode    => '0644',
       content => file('/etc/puppetlabs/puppet/ssl/certs/pe-internal-peadmin-mcollective-client.pem'),
   }
 


### PR DESCRIPTION
peadmin-cert.pem does not need to have +x permissions.  This PR brings the behavior in line with an upgraded install, which will have the permissions on this file set to 0644.