### PR TITLE
Update webhook.pp - adjusted peadmin-cert.pem

### DIFF
--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -41,7 +41,8 @@ class r10k::webhook(
 
   # 3.7 does not place the certificate in peadmin's ~
   # This places it there as if it was an upgrade
-  file { '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem':
+  file { 'peadmin-cert.pem':
+      path    => '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem',
       ensure  => 'file',
       owner   => 'peadmin',
       group   => 'peadmin',


### PR DESCRIPTION
When path is used as namevar, had a conflict on PE 3.3:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: File[/var/lib/peadmin/.mcollective.d/peadmin-cert.pem] is already declared in file /opt/puppet/share/puppet/modules/pe_mcollective/manifests/client/peadmin.pp:76; cannot redeclare at /etc/puppetlabs/puppet/environments/dev/modules/r10k/manifests/webhook.pp:50 on node example.puppet.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

Moved path to dedicated attribute and shortened namevar.