### PR TITLE
added metadata.json file for puppet versions 3.6 and older

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,50 @@
+{
+  "author": "Zach Smith",
+  "license": "Apache License, Version 2.0",
+  "name": "zack-r10k",
+  "operatingsystem_support": [],
+  "project_page": "https://github.com/acidprime/r10k",
+  "requirements": [],
+  "source": "https://github.com/acidprime/r10k",
+  "summary": "Module for setting up dynamic environments using r10k",
+  "tags": ["git", "pe", "environment", "mcollective"],
+  "version": "2.5.4",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 3.2.0"
+    },
+    {
+      "name": "puppetlabs/ruby",
+      "version_requirement": ">= 0.0.2"
+    },
+    {
+      "name": "puppetlabs/gcc",
+      "version_requirement": ">= 0.0.3"
+    },
+    {
+      "name": "puppetlabs/pe_gem",
+      "version_requirement": ">= 0.0.1"
+    },
+    {
+      "name": "croddy/make",
+      "version_requirement": ">= 0.0.3"
+    },
+    {
+      "name": "puppetlabs/inifile",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "puppetlabs/vcsrepo",
+      "version_requirement": ">= 0.1.2"
+    },
+    {
+      "name": "puppetlabs/git",
+      "version_requirement": ">= 0.0.3"
+    },
+    {
+      "name": "gentoo/portage",
+      "version_requirement": ">= 2.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
if r10k module is installed via Puppetfile/git PE 3.3 and older do not show version number. 
I converted existing Modulefile into metadata.json. Modulefile has been removed from puppetlabs modules for quite awhile now