### PR TITLE
Use 0.0.0.0 as default webhook bind address

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class r10k::params
   # Webhook configuration information
   $webhook_user               = 'puppet'
   $webhook_pass               = 'puppet'
-  $webhook_bind_address       = $::ipaddress
+  $webhook_bind_address       = '0.0.0.0'
   $webhook_port               = '8088'
   $webhook_access_logfile     = '/var/log/webhook/access.log'
   $webhook_mco_logfile        = '/var/log/webhook/mco_output.log'


### PR DESCRIPTION
This resolves an issue caused by #123 wherein the webhook will accept connections only on the first network interface listed.  Setting 0.0.0.0 as the bind address makes the webhook accept connections on all interfaces.