### PR TITLE
Support Puppet v3.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.1"
   - PUPPET_VERSION="~> 3.6.0"
+  - PUPPET_VERSION="~> 3.7.0"
+
 global:
     - PUBLISHER_LOGIN=acidprime
 matrix:


### PR DESCRIPTION
Without this patch, the current version of Puppet is not tested.