### PR TITLE
issue #132 making peadmin-cert.pem execute before webhook init script

### DIFF
--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -69,6 +69,7 @@ class r10k::webhook(
         group   => 'peadmin',
         mode    => '0644',
         content => file('/etc/puppetlabs/puppet/ssl/certs/pe-internal-peadmin-mcollective-client.pem'),
+        before  => File['webhook_init_script'],
     }
   }
 }


### PR DESCRIPTION
seeing failures on vagrant installs.  probably only relevant for new installs or vagrant boxes.

==> master: Notice: /Stage[main]/R10k::Webhook/Package[sinatra]/ensure: created
==> master: Notice: /Stage[main]/R10k::Webhook/File[webhook_init_script]/ensure: defined content as '{md5}7d9970c5e7b22b19c1c71b810eed0c37'
==> master: Notice: /Stage[main]/R10k::Webhook/File[webhook_bin]/ensure: defined content as '{md5}4fc99661c62c267609bd9507fbafcd71'
==> master: Error: Could not start Service[webhook]: Execution of '/sbin/service webhook start' returned 1: Starting webhook: /usr/local/bin/  webhook:50:in `initialize': No such file or directory - /var/lib/peadmin/.mcollective.d/peadmin-cert.pem (Errno::ENOENT)
==> master:   from /usr/local/bin/webhook:50:in `open'
==> master:   from /usr/local/bin/webhook:50:in `<main>'
==> master: [FAILED]
==> master: Wrapped exception:
==> master: Execution of '/sbin/service webhook start' returned 1: Starting webhook: /usr/local/bin/webhook:50:in `initialize': No such file   or directory - /var/lib/peadmin/.mcollective.d/peadmin-cert.pem (Errno::ENOENT)
==> master:   from /usr/local/bin/webhook:50:in `open'
==> master:   from /usr/local/bin/webhook:50:in `<main>'
==> master: [FAILED]
==> master: Error: /Stage[main]/R10k::Webhook/Service[webhook]/ensure: change from stopped to running failed: Could not start                  Service[webhook]: Execution of '/sbin/service webhook start' returned 1: Starting webhook: /usr/local/bin/webhook:50:in `initialize': No such  file or directory - /var/lib/peadmin/.mcollective.d/peadmin-cert.pem (Errno::ENOENT)
==> master:   from /usr/local/bin/webhook:50:in `open'
==> master:   from /usr/local/bin/webhook:50:in `<main>'
==> master: [FAILED]
==> master: Notice: /Stage[main]/R10k::Webhook/Service[webhook]: Triggered 'refresh' from 2 events
==> master: Notice: /Stage[main]/R10k::Webhook/File[peadmin-cert.pem]/ensure: defined content as '{md5}79327e3c3e70b2f2f441dee41f8c1e95'
==> master: Notice: /Stage[main]/Main/Service[pe-mcollective]: Triggered 'refresh' from 2 events