### PR TITLE
support for 'user' argument to su to another user when executing git and R10K

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,19 @@ You can sync an individual module using:
 mco r10k deploy_module <module>
 ```
 
+If you are required to run `r10k` as a specific user, you can do so by passing
+the `user` parameter:
+
+```shell
+mco r10k synchronize user=r10k
+```
+
+Too obtain the output of running the shell command, run the agent like this:
+
+```shell
+mco rpc r10k synchronize -v
+```
+
 An example post-receive hook is included in the files directory.
 This hook can automatically cause code to synchronize on your
 servers at time of push in git. More modern git systems use webhooks, for  those see below.

--- a/files/agent/r10k.ddl
+++ b/files/agent/r10k.ddl
@@ -18,6 +18,14 @@ metadata :name        => "r10k",
            :optional    => false,
            :maxlength   => 256
 
+   input :user,
+           :prompt      => "User",
+           :description => "User to run as",
+           :type        => :string,
+           :validation  => '\w+',
+           :optional    => true,
+           :maxlength   => 32
+
    output :path,
           :description => "Operating on #{act}",
           :display_as  => "Path"
@@ -36,6 +44,14 @@ end
  'synchronize',
  'sync'].each do |act|
   action act, :description => "#{act.capitalize} " do
+   input :user,
+           :prompt      => "User",
+           :description => "User to run as",
+           :type        => :string,
+           :validation  => '\w+',
+           :optional    => true,
+           :maxlength   => 32
+
     output :output,
            :description => "Output from git",
            :display_as  => "Output"
@@ -55,6 +71,14 @@ action 'deploy', :description => "Deploy a specific environment, and its Puppetf
         :validation => '.',
         :optional => true,
         :maxlength => 256
+
+  input :user,
+        :prompt      => "User",
+        :description => "User to run as",
+        :type        => :string,
+        :validation  => '\w+',
+        :optional    => true,
+        :maxlength   => 32
 
   output :environment,
          :description => "Deploy a particular environment",
@@ -79,6 +103,14 @@ action 'deploy_module', :description => "Deploy a specific module" do
         :validation => '.',
         :optional => true,
         :maxlength => 256
+
+  input :user,
+        :prompt      => "User",
+        :description => "User to run as",
+        :type        => :string,
+        :validation  => '\w+',
+        :optional    => true,
+        :maxlength   => 32
 
   output :module_name,
          :description => "Deploy a particular module",


### PR DESCRIPTION
I've taken on-board the suggestions from https://github.com/acidprime/r10k/issues/135 and developed this PR to address it.

The patch works by checking for the presence of a `user` argument.  If this is present and matches the regexp `^\w+$`, we will try to invoke `git` or `r10k` by doing `su - $user -c 'COMMAND'`.

I've modified the agent to support `user` on all operations and verified that I still receive output and errors, as you can see from the following console captures:

**r10k status**
```
peadmin@xmaster:~$ mco rpc  r10k status user=r10k path=/etc/puppetlabs/puppet/environments/production/modules/ntp -v
Discovering hosts using the mc method for 2 second(s) .... 1

 * [ =========================================================> ] 1 / 1


xmaster.vagrant.vm                      : OK
    {:path=>"/etc/puppetlabs/puppet/environments/production/modules/ntp",     :output=>      "# Not currently on any branch.\nnothing to commit (working directory clean)",     :error=>"",     :status=>0}
```

**r10k deploy_module**
```
peadmin@xmaster:~$ mco rpc r10k deploy_module module_name=ntp user=r10k environment=production
Discovering hosts using the mc method for 2 second(s) .... 1

 * [ =========================================================> ] 1 / 1


xmaster.vagrant.vm                       
            Errors:
   Specific module: ntp
            Output:
            status: 0
```

**r10k sync**
```
peadmin@xmaster:~$ mco rpc  r10k sync user=r10k -v
Discovering hosts using the mc method for 2 second(s) .... 1

 * [ =========================================================> ] 1 / 1


xmaster.vagrant.vm                      : OK
    {:output=>"",     :error=>      "[R10K::Action::Deploy::Environment - ERROR] Command exited with non-zero exit code:\nCommand: git --git-dir /etc/puppetlabs/puppet/environments/production/modules/ruby/.git --work-tree /etc/puppetlabs/puppet/environments/production/modules/ruby remote set-url cache /var/cache/r10k/https---github.com-puppetlabs-puppetlabs-ruby.git\nStderr:\nfatal: No such remote 'cache'\nExit code: 128",     :status=>1}
```
*As you can see, there is a strange error here caused by a partial failure and this gets captured too.  I got the same error running `r10k` on the command line so its legit*

Thanks Eli, Brett and Zack for your help figuring this one out.


