### PR TITLE
fix for /var/run being mounted on tmpfs in ubuntu 14.04

### DIFF
--- a/templates/webhook.init.erb
+++ b/templates/webhook.init.erb
@@ -9,6 +9,13 @@
 # processname: webhook
 
 [ -f /etc/sysconfig/webhook ] && . /etc/sysconfig/webhook
+
+# This is for ubuntu 14.04 (/var/run is mount to tmpfs)
+if [ !-d /var/run/webhook ]; then
+  mkdir -p /var/run/webhook
+  chown <%= @user %> /var/run/webhook
+fi
+
 pidfile='/var/run/webhook/webhook.pid'
 webhook='/usr/local/bin/webhook'
 DAEMON_USER='<%= @user %>'


### PR DESCRIPTION
Ubuntu 14.04 is using a link to /run from /var/run.  The /run mount point is mounted on tmpfs which breaks the init scripts ability to start after a reboot.  This commit checks for the /var/run/webhood dir and creates it if it does not exist.

