### PR TITLE
Support of Puppet FOSS for Webhook

### DIFF
--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -16,17 +16,17 @@ class r10k::mcollective (
     mode   => '0644',
   }
   # Install the agent and its ddl file
-  file { "${app_path}/${app_name}"  :
+  file { "${app_path}/${app_name}":
     source => "puppet:///modules/${module_name}/application/${agent_name}",
   }
 
-  file { "${agent_path}/${agent_ddl}"  :
+  file { "${agent_path}/${agent_ddl}":
     source => "puppet:///modules/${module_name}/agent/${agent_ddl}",
   }
 
   # Install the application file (all masters at the moment)
-  file { "${agent_path}/${agent_name}" :
-    content  => template("${module_name}/agent/${agent_name}.erb"),
+  file { "${agent_path}/${agent_name}":
+    content => template("${module_name}/agent/${agent_name}.erb"),
     require => File["${agent_path}/${agent_ddl}"],
   }
 

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -6,6 +6,8 @@ class r10k::mcollective(
   $agent_path        = $r10k::params::mc_agent_path,
   $app_path          = $r10k::params::mc_application_path,
   $mc_service        = $r10k::params::mc_service_name,
+  $http_proxy        = $r10k::params::mc_http_proxy,
+  $git_ssl_verify    = $r10k::params::mc_git_ssl_verify,
 ) inherits r10k::params {
   File {
     ensure => present,
@@ -24,7 +26,7 @@ class r10k::mcollective(
 
   # Install the application file (all masters at the moment)
   file { "${agent_path}/${agent_name}" :
-    source  => "puppet:///modules/${module_name}/agent/${agent_name}",
+    content  => template("puppet:///modules/${module_name}/agent/${agent_name}.erb"),
     require => File["${agent_path}/${agent_ddl}"],
   }
 

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -26,7 +26,7 @@ class r10k::mcollective(
 
   # Install the application file (all masters at the moment)
   file { "${agent_path}/${agent_name}" :
-    content  => template("puppet:///modules/${module_name}/agent/${agent_name}.erb"),
+    content  => template("${module_name}/agent/${agent_name}.erb"),
     require => File["${agent_path}/${agent_ddl}"],
   }
 

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -1,5 +1,5 @@
 # Install the r10k mcollective agent
-class r10k::mcollective(
+class r10k::mcollective (
   $agent_name        = $r10k::params::mc_agent_name,
   $app_name          = $r10k::params::mc_app_name,
   $agent_ddl         = $r10k::params::mc_agent_ddl_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -102,4 +102,6 @@ class r10k::params
   $mc_app_name         = "${module_name}.rb"
   $mc_agent_path       = "${plugins_dir}/agent"
   $mc_application_path = "${plugins_dir}/application"
+  $mc_http_proxy       = undef
+  $mc_git_ssl_verify   = 0
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,8 @@ class r10k::params
   $webhook_enable_ssl            = true
   $webhook_use_mcollective       = true
   $webhook_r10k_deploy_arguments = '-pv'
+  $webhook_public_key_path       = undef
+  $webhook_private_key_path      = undef
 
   if $::osfamily == Debian {
     $functions_path     = '/lib/lsb/init-functions'

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -35,8 +35,8 @@ class r10k::webhook(
 
   file { 'webhook_bin':
     content => template('r10k/webhook.bin.erb'),
-    path   => '/usr/local/bin/webhook',
-    notify => Service['webhook'],
+    path    => '/usr/local/bin/webhook',
+    notify  => Service['webhook'],
   }
 
   service { 'webhook':
@@ -57,7 +57,7 @@ class r10k::webhook(
       }
       # 3.7 does not place the certificate in peadmin's ~
       # This places it there as if it was an upgrade
-      file { "peadmin-cert.pem":
+      file { 'peadmin-cert.pem':
           ensure  => 'file',
           path    => '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem',
           owner   => 'peadmin',

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -34,7 +34,7 @@ class r10k::webhook(
   }
 
   file { 'webhook_bin':
-    source => 'puppet:///modules/r10k/webhook',
+    content => template('r10k/webhook.bin.erb'),
     path   => '/usr/local/bin/webhook',
     notify => Service['webhook'],
   }
@@ -46,32 +46,61 @@ class r10k::webhook(
     hasstatus => false,
   }
 
-  if !defined(Package['sinatra']) {
-    package { 'sinatra':
-      ensure   => installed,
-      provider => 'pe_gem',
-      before   => Service['webhook'],
+  if $::is_pe == true or $::is_pe == 'true' {
+    if versioncmp($::pe_version, '3.7.0') >= 0 {
+      if !defined(Package['rack']) {
+        package { 'rack':
+          ensure   => installed,
+          provider => 'pe_gem',
+          before   => Service['webhook'],
+        }
+      }
+      # 3.7 does not place the certificate in peadmin's ~
+      # This places it there as if it was an upgrade
+      file { "peadmin-cert.pem":
+          ensure  => 'file',
+          path    => '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem',
+          owner   => 'peadmin',
+          group   => 'peadmin',
+          mode    => '0644',
+          content => file('/etc/puppetlabs/puppet/ssl/certs/pe-internal-peadmin-mcollective-client.pem'),
+          notify  => Service['webhook'],
+      }
     }
   }
-
-  if versioncmp($::pe_version, '3.7.0') >= 0{
-    if !defined(Package['rack']) {
-      package { 'rack':
+  else {
+    if !defined(Package['webrick']) {
+      package { 'webrick':
         ensure   => installed,
-        provider => 'pe_gem',
+        provider => 'gem',
         before   => Service['webhook'],
       }
     }
-    # 3.7 does not place the certificate in peadmin's ~
-    # This places it there as if it was an upgrade
-    file { 'peadmin-cert.pem':
-        ensure  => 'file',
-        path    => '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem',
-        owner   => 'peadmin',
-        group   => 'peadmin',
-        mode    => '0644',
-        content => file('/etc/puppetlabs/puppet/ssl/certs/pe-internal-peadmin-mcollective-client.pem'),
-        notify  => Service['webhook'],
+
+    if !defined(Package['json']) {
+      package { 'json':
+        ensure   => installed,
+        provider => 'gem',
+        before   => Service['webhook'],
+      }
+    }
+
+    if !defined(Package['sinatra']) {
+      package { 'sinatra':
+        ensure   => installed,
+        provider => 'gem',
+        before   => Service['webhook'],
+      }
+    }
+
+    if versioncmp($::puppetversion, '3.7.0') >= 0 {
+      if !defined(Package['rack']) {
+        package { 'rack':
+          ensure   => installed,
+          provider => 'gem',
+          before   => Service['webhook'],
+        }
+      }
     }
   }
 }

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -25,6 +25,8 @@ class r10k::webhook::config (
   $enable_ssl            = $r10k::params::webhook_enable_ssl,
   $use_mcollective       = $r10k::params::webhook_use_mcollective,
   $r10k_deploy_arguments = $r10k::params::webhook_r10k_deploy_arguments,
+  $public_key_path       = $r10k::params::webhook_public_key_path,
+  $private_key_path      = $r10k::params::webhook_private_key_path,
   $configfile            = '/etc/webhook.yaml',
 ) inherits r10k::params {
 
@@ -49,6 +51,8 @@ class r10k::webhook::config (
       'enable_ssl'            => $enable_ssl,
       'use_mcollective'       => $use_mcollective,
       'r10k_deploy_arguments' => $r10k_deploy_arguments,
+      'public_key_path'       => $public_key_path,
+      'private_key_path'      => $private_key_path,
     }
   } else {
     validate_hash($hash)

--- a/templates/agent/r10k.rb.erb
+++ b/templates/agent/r10k.rb.erb
@@ -56,14 +56,14 @@ module MCollective
         git  = ['/usr/bin/env', 'git']
         r10k = ['/usr/bin/env', 'r10k']
         # Given most people using this are using Puppet Enterprise, add the PE Path
-        environment = {"LC_ALL" => "C","PATH" => "#{ENV['PATH']}:/opt/puppet/bin"}
+        environment = {"LC_ALL" => "C","PATH" => "#{ENV['PATH']}:<%= @::is_pe == true or @::is_pe == 'true' ? '/opt/puppet/bin' : '/usr/local/bin' %>", "http_proxy" => "<%= @http_proxy %>", "https_proxy" => "<%= @http_proxy %>", "GIT_SSL_NO_VERIFY" => "<%= @git_ssl_verify %>" }
         case action
           when 'push','pull','status'
             cmd = git
             cmd << 'push'   if action == 'push'
             cmd << 'pull'   if action == 'pull'
             cmd << 'status' if action == 'status'
-            reply[:status] = run(cmd_as_user(cmd, arg), :stderr => :error, :stdout => :output, :chomp => true, :cwd => arg, :environment => environment  )
+            reply[:status] = run(cmd_as_user(cmd, arg), :stderr => :error, :stdout => :output, :chomp => true, :cwd => arg, :environment => environment )
           when 'cache','synchronize','sync', 'deploy', 'deploy_module'
             cmd = r10k
             cmd << 'cache' if action == 'cache'

--- a/templates/agent/r10k.rb.erb
+++ b/templates/agent/r10k.rb.erb
@@ -56,7 +56,7 @@ module MCollective
         git  = ['/usr/bin/env', 'git']
         r10k = ['/usr/bin/env', 'r10k']
         # Given most people using this are using Puppet Enterprise, add the PE Path
-        environment = {"LC_ALL" => "C","PATH" => "#{ENV['PATH']}:<%= @::is_pe == true or @::is_pe == 'true' ? '/opt/puppet/bin' : '/usr/local/bin' %>", "http_proxy" => "<%= @http_proxy %>", "https_proxy" => "<%= @http_proxy %>", "GIT_SSL_NO_VERIFY" => "<%= @git_ssl_verify %>" }
+        environment = {"LC_ALL" => "C","PATH" => "#{ENV['PATH']}:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>", "http_proxy" => "<%= @http_proxy %>", "https_proxy" => "<%= @http_proxy %>", "GIT_SSL_NO_VERIFY" => "<%= @git_ssl_verify %>" }
         case action
           when 'push','pull','status'
             cmd = git

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -37,11 +37,8 @@ $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)
 
 <% if @is_pe == true or @is_pe == 'true' %>
 # PE 3.7 check for renamed certificate path
-public_key_path  = File.join("#{$config['certpath']}", "#{$config['certname']}-cert.pem")
-private_key_path = File.join("#{$config['certpath']}", "#{$config['certname']}-private.pem")
-<% else %> 
-public_key_path  = 
-private_key_path = 
+config['public_key_path']  = File.join("#{$config['certpath']}", "#{$config['certname']}-cert.pem")
+config['private_key_path'] = File.join("#{$config['certpath']}", "#{$config['certname']}-private.pem")
 <% end %>
 
 opts = {
@@ -129,10 +126,10 @@ class Server < Sinatra::Base
     def deploy_module(module_name)
       begin
         if $config['use_mcollective']
-          command = "/opt/puppet/bin/mco r10k deploy_module #{module_name} >> #{$config['mco_logfile']} 2>&1 &"
+          command = "mco r10k deploy_module #{module_name} >> #{$config['mco_logfile']} 2>&1 &"
         else
           # If you don't use mcollective then this hook needs to be running as r10k's user i.e. root
-          command = "/opt/puppet/bin/r10k deploy module #{module_name} >> #{$config['mco_logfile']} 2>&1 &"
+          command = "r10k deploy module #{module_name} >> #{$config['mco_logfile']} 2>&1 &"
         end
         message = "triggered: #{command}"
         Process.detach(fork{ exec "#{command}"})
@@ -155,10 +152,10 @@ class Server < Sinatra::Base
           end
         else
           if $config['use_mcollective']
-              command = "/opt/puppet/bin/mco r10k deploy #{branch} >> #{$config['mco_logfile']} 2>&1 &"
+              command = "mco r10k deploy #{branch} >> #{$config['mco_logfile']} 2>&1 &"
           else
             # If you don't use mcollective then this hook needs to be running as r10k's user i.e. root
-            command = "/opt/puppet/bin/r10k deploy environment #{branch} #{$config['r10k_deploy_arguments']} >> #{$config['mco_logfile']} 2>&1 &"
+            command = "r10k deploy environment #{branch} #{$config['r10k_deploy_arguments']} >> #{$config['mco_logfile']} 2>&1 &"
           end
           message = "triggered: #{command}"
           Process.detach(fork{ exec "#{command}"})

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -40,8 +40,8 @@ $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)
 public_key_path  = File.join("#{$config['certpath']}", "#{$config['certname']}-cert.pem")
 private_key_path = File.join("#{$config['certpath']}", "#{$config['certname']}-private.pem")
 <% else %> 
-public_key_path  = "#{$config['public_key_path']}"
-private_key_path = "#{$config['private_key_path']}"
+public_key_path  = 
+private_key_path = 
 <% end %>
 
 opts = {
@@ -51,8 +51,8 @@ opts = {
         :ServerType         => WEBrick::Daemon,
         :SSLEnable          => $config['enable_ssl'],
         :SSLVerifyClient    => OpenSSL::SSL::VERIFY_NONE,
-        :SSLCertificate     => OpenSSL::X509::Certificate.new(  File.open("#{public_key_path}").read),
-        :SSLPrivateKey      => OpenSSL::PKey::RSA.new(          File.open("#{private_key_path}").read),
+        :SSLCertificate     => OpenSSL::X509::Certificate.new(File.open("#{$config['public_key_path']}").read),
+        :SSLPrivateKey      => OpenSSL::PKey::RSA.new(File.open("#{$config['private_key_path']}").read),
         :SSLCertName        => [ [ "CN",WEBrick::Utils::getservername ] ]
 }
 

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,4 +1,4 @@
-#!/opt/puppet/bin/ruby
+#!<%= @::is_pe == true or @::is_pe == 'true' ? '/opt/puppet/bin' : '/usr/bin' %>/ruby
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster
 # Authors:
@@ -30,15 +30,19 @@ else
   raise "Configuration file: #{WEBHOOK_CONFIG} does not exist"
 end
 
-ENV['HOME'] = '/var/lib/peadmin'
-ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:/opt/puppet/bin'
+ENV['HOME'] = '/var/lib/<%= @user %>'
+ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:<%= @::is_pe == true or @::is_pe == 'true' ? '/opt/puppet/bin' : '/usr/local/bin' %>'
 
 $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)
 
+<% if @::is_pe == true or @::is_pe == 'true' %>
 # PE 3.7 check for renamed certificate path
 public_key_path  = File.join("#{$config['certpath']}", "#{$config['certname']}-cert.pem")
-
 private_key_path = File.join("#{$config['certpath']}", "#{$config['certname']}-private.pem")
+<% else %> 
+public_key_path  = File.join("#{$config['certpath']}", "#{$config['certname']}")
+private_key_path = File.join("#{$config['certpath']}", "#{$config['certname']}")
+<% end %> 
 
 opts = {
         :Host               => $config['bind_address'],
@@ -52,7 +56,7 @@ opts = {
         :SSLCertName        => [ [ "CN",WEBrick::Utils::getservername ] ]
 }
 
-class Server  < Sinatra::Base
+class Server < Sinatra::Base
 
   set :static, false
 

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,4 +1,4 @@
-#!<%= @::is_pe == true or @::is_pe == 'true' ? '/opt/puppet/bin' : '/usr/bin' %>/ruby
+#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/bin' end %>/ruby
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster
 # Authors:
@@ -31,18 +31,18 @@ else
 end
 
 ENV['HOME'] = '/var/lib/<%= @user %>'
-ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:<%= @::is_pe == true or @::is_pe == 'true' ? '/opt/puppet/bin' : '/usr/local/bin' %>'
+ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>'
 
 $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)
 
-<% if @::is_pe == true or @::is_pe == 'true' %>
+<% if @is_pe == true or @is_pe == 'true' %>
 # PE 3.7 check for renamed certificate path
 public_key_path  = File.join("#{$config['certpath']}", "#{$config['certname']}-cert.pem")
 private_key_path = File.join("#{$config['certpath']}", "#{$config['certname']}-private.pem")
 <% else %> 
-public_key_path  = File.join("#{$config['certpath']}", "#{$config['certname']}")
-private_key_path = File.join("#{$config['certpath']}", "#{$config['certname']}")
-<% end %> 
+public_key_path  = "#{$config['public_key_path']}"
+private_key_path = "#{$config['private_key_path']}"
+<% end %>
 
 opts = {
         :Host               => $config['bind_address'],
@@ -51,8 +51,8 @@ opts = {
         :ServerType         => WEBrick::Daemon,
         :SSLEnable          => $config['enable_ssl'],
         :SSLVerifyClient    => OpenSSL::SSL::VERIFY_NONE,
-        :SSLCertificate     => OpenSSL::X509::Certificate.new(  File.open(File.join("#{public_key_path}")).read),
-        :SSLPrivateKey      => OpenSSL::PKey::RSA.new(          File.open(File.join("#{private_key_path}")).read),
+        :SSLCertificate     => OpenSSL::X509::Certificate.new(  File.open("#{public_key_path}").read),
+        :SSLPrivateKey      => OpenSSL::PKey::RSA.new(          File.open("#{private_key_path}").read),
         :SSLCertName        => [ [ "CN",WEBrick::Utils::getservername ] ]
 }
 

--- a/templates/webhook.init.erb
+++ b/templates/webhook.init.erb
@@ -1,5 +1,5 @@
 #!/bin/bash
-# webhook        Init script for running the r10k webhook daemon
+# webhook       Init script for running the r10k webhook daemon
 #
 # Author:       Zack Smith <zack.smith@puppetlabs.com>
 #
@@ -30,7 +30,7 @@ export PATH
 start() {
     echo
     echo -n $"Starting webhook: "
-    daemon --user ${DAEMON_USER:?} <%= scope.lookupvar('r10k::params::start_pidfile_args') %> $webhook
+    start-stop-daemon --start --user ${DAEMON_USER:?} <%= scope.lookupvar('r10k::params::start_pidfile_args') %> --startas=$webhook
     RETVAL=$?
     return $RETVAL
 }


### PR DESCRIPTION
I implemented the support of FOSS for the webhook. I currently only tested on Ubuntu 14.04.2 LTS
Some other enhancements : 
- Set GIT_SSL_NO_VERIFY if necessary
- Definition of a http_proxy to access remote repositories
- Custom mcollective cert files location

Example usage : 

```puppet
class { '::r10k::mcollective':
  http_proxy     => 'http://proxy.example.lan:3128',
  git_ssl_verify => 1,
}

class { '::r10k::webhook::config':
  enable_ssl       => false,
  protected        => false,
  public_key_path  => '/etc/mcollective/server_public.pem',  # Mandatory for FOSS
  private_key_path => '/etc/mcollective/server_private.pem', # Mandatory for FOSS
  notify           => Service['webhook'],
}

class { '::r10k::webhook':
  user    => 'puppet',                                       # Mandatory for FOSS
  group   => 'puppet',                                       # Mandatory for FOSS
  require => Class['::r10k::webhook::config'],
}
```