### PR TITLE
Full path to r10k in postrun command

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class r10k::params
   $remote     = "ssh://${git_server}${repo_path}/modules.git"
 
   # prerun_command in puppet.conf
-  $pre_postrun_command = 'r10k deploy environment -p'
+  $pre_postrun_command = '/usr/local/bin/r10k deploy environment -p'
 
   # Gentoo specific values
   $gentoo_keywords = ''


### PR DESCRIPTION
When I was triggering puppet runs with mco puppet agent it wasn't finding r10k for some reason. Error message from puppet was "Could not execute posix command: No such file or directory". Manual runs were fine. Providing the full path seems to do the trick. Probably a good practice anyway.