### PR TITLE
Update r10k gem version for v2.7.x module version

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can override this by passing the `version` parameter.
 | Module Version | r10k Version |
 | -------------- | ------------ |
 | Next Release   | [![Latest Version](https://img.shields.io/gem/v/r10k.svg?style=flat-square)](https://rubygems.org/gems/r10k)        |
-| v2.7.x         | 1.5.0        |
+| v2.7.x         | 1.5.1        |
 | v2.6.5         | 1.4.1        |
 | v2.5.4         | 1.4.0        |
 | v2.4.4         | 1.3.5        |


### PR DESCRIPTION
r10k gem v1.5.0 was yanked and current params class defaults to v1.5.1