### PR TITLE
add logic to prevent issue with pe_version on foss puppet with strict_variables enabled

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -65,7 +65,7 @@ class r10k::install (
       # Puppet Enterprise 3.8 and ships an embedded r10k so thats all thats supported
       # This conditional should not effect FOSS customers based on the fact unless 
       # $provider is set to 'pe_gem' on a system without PE installed
-      unless $provider == 'pe_gem' and versioncmp($::pe_version, '3.8.0') >= 0 {
+      unless getvar('::pe_version') and versioncmp($::pe_version, '3.8.0') >= 0 {
         package { $real_package_name:
           ensure          => $version,
           provider        => $provider,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -64,7 +64,7 @@ class r10k::install (
 
       # Puppet Enterprise 3.8 and ships an embedded r10k so thats all thats supported
       # This conditional should not effect FOSS customers based on the fact 
-      unless getvar('::pe_version') and versioncmp($::pe_version, '3.8.0') >= 0 {
+      unless ($::is_pe == 'true' or $::is_pe == true) and versioncmp($::pe_version, '3.8.0') >= 0 {
         package { $real_package_name:
           ensure          => $version,
           provider        => $provider,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,8 +63,7 @@ class r10k::install (
       }
 
       # Puppet Enterprise 3.8 and ships an embedded r10k so thats all thats supported
-      # This conditional should not effect FOSS customers based on the fact unless 
-      # $provider is set to 'pe_gem' on a system without PE installed
+      # This conditional should not effect FOSS customers based on the fact 
       unless getvar('::pe_version') and versioncmp($::pe_version, '3.8.0') >= 0 {
         package { $real_package_name:
           ensure          => $version,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,8 +63,9 @@ class r10k::install (
       }
 
       # Puppet Enterprise 3.8 and ships an embedded r10k so thats all thats supported
-      # This conditional should not effect FOSS customers based on the fact
-      unless versioncmp($::pe_version, '3.8.0') >= 0 {
+      # This conditional should not effect FOSS customers based on the fact unless 
+      # $provider is set to 'pe_gem' on a system without PE installed
+      unless $provider == 'pe_gem' and versioncmp($::pe_version, '3.8.0') >= 0 {
         package { $real_package_name:
           ensure          => $version,
           provider        => $provider,

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -207,7 +207,7 @@ describe 'r10k::install' , :type => 'class' do
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '5',
         :operatingsystem        => 'Centos',
-        :is_pe                  => '',
+        :is_pe                  => true,
         :pe_version             => '3.8.1'
       }
     end


### PR DESCRIPTION
Fix to #160 which prevents $::pe_version from being evaluated unless $provider is set to 'pe_gem'.  

