### PR TITLE
Add support for OpenBSD, some noteworthy points to mention:

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,6 +20,7 @@ class r10k::install (
 
   if $package_name == '' {
     case $provider {
+      'openbsd': { $real_package_name = 'ruby21-r10k' }
       'portage': { $real_package_name = 'app-admin/r10k' }
       'yum':     { $real_package_name = 'rubygem-r10k' }
       default:   { $real_package_name = 'r10k' }
@@ -39,7 +40,7 @@ class r10k::install (
         version      => $version,
       }
     }
-    'pe_gem', 'gem', 'yum', 'zypper': {
+    'pe_gem', 'gem', 'openbsd', 'yum', 'zypper': {
       if $provider == 'gem' {
         class { 'r10k::install::gem':
           manage_ruby_dependency => $manage_ruby_dependency,
@@ -72,6 +73,6 @@ class r10k::install (
         }
       }
     }
-    default: { fail("${provider} is not supported. Valid values are: 'gem', 'pe_gem', 'bundle', 'portage', 'yum', 'zypper'") }
+    default: { fail("${module_name}: ${provider} is not supported. Valid values are: 'gem', 'pe_gem', 'bundle', 'openbsd', 'portage', 'yum', 'zypper'") }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,9 +21,6 @@ class r10k::params
   $repo_path  = '/var/repos'
   $remote     = "ssh://${git_server}${repo_path}/modules.git"
 
-  # prerun_command in puppet.conf
-  $pre_postrun_command = 'r10k deploy environment -p'
-
   # Gentoo specific values
   $gentoo_keywords = ''
 
@@ -70,33 +67,51 @@ class r10k::params
     $plugins_dir     = '/opt/puppet/libexec/mcollective/mcollective'
     $modulepath      = "${r10k_basedir}/\$environment/modules:${pe_module_path}"
     $provider        = 'pe_gem'
+    $r10k_binary     = 'r10k'
   } else {
     # Getting ready for FOSS support in this module
     $puppetconf_path = '/etc/puppet'
 
     # Mcollective configuration dynamic
-    $mc_service_name = 'mcollective'
     $modulepath = "${r10k_basedir}/\$environment/modules"
 
     case $::osfamily {
       'debian': {
-        $plugins_dir = '/usr/share/mcollective/plugins/mcollective'
-        $provider    = 'gem'
+        $plugins_dir     = '/usr/share/mcollective/plugins/mcollective'
+        $provider        = 'gem'
+        $r10k_binary     = 'r10k'
+        $mc_service_name = 'mcollective'
       }
       'gentoo': {
-        $plugins_dir = '/usr/libexec/mcollective/mcollective'
-        $provider    = 'portage'
+        $plugins_dir     = '/usr/libexec/mcollective/mcollective'
+        $provider        = 'portage'
+        $r10k_binary     = 'r10k'
+        $mc_service_name = 'mcollective'
       }
       'suse': {
-        $plugins_dir = '/usr/share/mcollective/plugins/mcollective'
-        $provider    = 'zypper'
+        $plugins_dir     = '/usr/share/mcollective/plugins/mcollective'
+        $provider        = 'zypper'
+        $r10k_binary     = 'r10k'
+        $mc_service_name = 'mcollective'
+      }
+      'openbsd': {
+        $plugins_dir     = '/usr/local/libexec/mcollective/mcollective'
+        $provider        = 'openbsd'
+        $r10k_binary     = 'r10k21'
+        $mc_service_name = 'mcollectived'
       }
       default: {
-        $plugins_dir = '/usr/libexec/mcollective/mcollective'
-        $provider    = 'gem'
+        $plugins_dir     = '/usr/libexec/mcollective/mcollective'
+        $provider        = 'gem'
+        $r10k_binary     = 'r10k'
+        $mc_service_name = 'mcollective'
       }
     }
   }
+
+  # prerun_command in puppet.conf
+  $pre_postrun_command = "${r10k_binary} deploy environment -p"
+
 
   # Mcollective configuration static
   $mc_agent_name       = "${module_name}.rb"

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -27,6 +27,31 @@ describe 'r10k::config' , :type => 'class' do
     }
     it { should_not contain_ini_setting("R10k Modulepath") }
   end
+  context "On OpenBSD configuring r10k with defaults" do
+    let :params do
+      {
+        :configfile        => '/etc/r10k.yaml',
+        :cachedir          => '/var/cache/r10k',
+        :manage_modulepath => false,
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false'
+      }
+    end
+    it { should contain_class("r10k::params") }
+    it { should contain_file("r10k.yaml").with(
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => '0',
+        'mode'   => '0644',
+        'path'   => '/etc/r10k.yaml'
+      )
+    }
+    it { should_not contain_ini_setting("R10k Modulepath") }
+  end
   context "Puppet Enterprise on a RedHat 5 OS configuring r10k and managing the modulepath" do
     let :params do
       {
@@ -60,6 +85,37 @@ describe 'r10k::config' , :type => 'class' do
       )
     }
   end
+  context "On OpenBSD configuring r10k and managing the modulepath" do
+    let :params do
+      {
+        :configfile        => '/etc/r10k.yaml',
+        :cachedir          => '/var/cache/r10k',
+        :manage_modulepath => true,
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false',
+      }
+    end
+    it { should contain_class("r10k::params") }
+    it { should contain_file("r10k.yaml").with(
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => '0',
+        'mode'   => '0644',
+        'path'   => '/etc/r10k.yaml'
+      )
+    }
+    it { should contain_ini_setting("R10k Modulepath").with(
+      'ensure'  => 'present',
+      'path'    => '/etc/puppet/puppet.conf',
+      'section' => 'main',
+      'setting' => 'modulepath'
+      )
+    }
+  end
   context "Puppet Enterprise on a RedHat 5 OS configuring r10k and forgetting to pass a hash" do
     let :params do
       {
@@ -75,6 +131,25 @@ describe 'r10k::config' , :type => 'class' do
         :operatingsystemrelease => '5',
         :operatingsystem        => 'Centos',
         :is_pe                  => 'true',
+      }
+    end
+    it 'should fail when sources is not a hash' do
+      expect { subject }.to raise_error(Puppet::Error, /is not a Hash/)
+    end
+  end
+  context "On OpenBSD configuring r10k and forgetting to pass a hash" do
+    let :params do
+      {
+        :configfile        => '/etc/r10k.yaml',
+        :cachedir          => '/var/cache/r10k',
+        :manage_modulepath => true,
+        :sources           => 'i-am-not-a-hash',
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false',
       }
     end
     it 'should fail when sources is not a hash' do
@@ -101,10 +176,28 @@ describe 'r10k::config' , :type => 'class' do
       expect { subject }.to raise_error(Puppet::Error, /is not a bool/)
     end
   end
+  context "On OpenBSD configuring r10k and forgetting to pass a bool" do
+    let :params do
+      {
+        :configfile        => '/etc/r10k.yaml',
+        :cachedir          => '/var/cache/r10k',
+        :manage_modulepath => 'false-i-am-not-a-bool',
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false',
+      }
+    end
+    it 'should fail when sources is not a boolean' do
+      expect { subject }.to raise_error(Puppet::Error, /is not a bool/)
+    end
+  end
 
   describe 'with manage_configfile_symlink' do
     ['true',true].each do |value|
-      context "set to #{value} with configfile specified and configfile_symlink left at the default value" do
+      context "On RedHat with PE set to #{value} with configfile specified and configfile_symlink left at the default value" do
         let :params do
           {
             :manage_configfile_symlink => value,
@@ -130,7 +223,31 @@ describe 'r10k::config' , :type => 'class' do
         }
       end
 
-      context "set to #{value} with configfile specified and configfile_symlink specified" do
+      context "On OpenBSD with Puppet FOSS set to #{value} with configfile specified and configfile_symlink left at the default value" do
+        let :params do
+          {
+            :manage_configfile_symlink => value,
+            :configfile                => '/etc/puppet/r10k.yaml',
+            :cachedir                  => '/var/cache/r10k',
+            :manage_modulepath         => false,
+          }
+        end
+        let :facts do
+          {
+            :osfamily               => 'OpenBSD',
+            :is_pe                  => 'false',
+          }
+        end
+
+        it { should contain_file('symlink_r10k.yaml').with({
+            'ensure' => 'link',
+            'path'   => '/etc/r10k.yaml',
+            'target' => '/etc/puppet/r10k.yaml',
+          })
+        }
+      end
+
+      context "On RedHat with PE set to #{value} with configfile specified and configfile_symlink specified" do
         let :params do
           {
             :manage_configfile_symlink => value,
@@ -157,7 +274,32 @@ describe 'r10k::config' , :type => 'class' do
         }
       end
 
-      context "set to #{value} without configfile_symlink specified" do
+      context "On OpenBSD with Puppet FOSS set to #{value} with configfile specified and configfile_symlink specified" do
+        let :params do
+          {
+            :manage_configfile_symlink => value,
+            :configfile                => '/etc/puppet/r10k.yaml',
+            :configfile_symlink        => '/tmp/r10k.yaml',
+            :cachedir                  => '/var/cache/r10k',
+            :manage_modulepath         => false,
+          }
+        end
+        let :facts do
+          {
+            :osfamily               => 'OpenBSD',
+            :is_pe                  => 'false',
+          }
+        end
+
+        it { should contain_file('symlink_r10k.yaml').with({
+            'ensure' => 'link',
+            'path'   => '/tmp/r10k.yaml',
+            'target' => '/etc/puppet/r10k.yaml',
+          })
+        }
+      end
+
+      context "On RedHat with PE set to #{value} without configfile_symlink specified" do
         let :params do
           {
             :manage_configfile_symlink => value,
@@ -181,10 +323,33 @@ describe 'r10k::config' , :type => 'class' do
           })
         }
       end
+
+      context "On OpenBSD with Puppet FOSS set to #{value} without configfile_symlink specified" do
+        let :params do
+          {
+            :manage_configfile_symlink => value,
+            :configfile                => '/etc/puppet/r10k.yaml',
+            :cachedir                  => '/var/cache/r10k',
+            :manage_modulepath         => false,
+          }
+        end
+        let :facts do
+          {
+            :osfamily               => 'OpenBSD',
+            :is_pe                  => 'false',
+          }
+        end
+        it { should contain_file('symlink_r10k.yaml').with({
+            'ensure' => 'link',
+            'path'   => '/etc/r10k.yaml',
+            'target' => '/etc/puppet/r10k.yaml',
+          })
+        }
+      end
     end
 
     ['false',false].each do |value|
-      context "set to #{value}" do
+      context "On RedHat with PE set to #{value}" do
         let :params do
           {
             :manage_configfile_symlink => value,
@@ -204,9 +369,27 @@ describe 'r10k::config' , :type => 'class' do
 
         it { should_not contain_file('symlink_r10k.yaml') }
       end
+      context "On OpenBSD with Puppet FOSS set to #{value}" do
+        let :params do
+          {
+            :manage_configfile_symlink => value,
+            :configfile                => '/etc/puppet/r10k.yaml',
+            :cachedir                  => '/var/cache/r10k',
+            :manage_modulepath         => false,
+          }
+        end
+        let :facts do
+          {
+            :osfamily               => 'OpenBSD',
+            :is_pe                  => 'false',
+          }
+        end
+
+        it { should_not contain_file('symlink_r10k.yaml') }
+      end
     end
 
-    context 'set to a non-boolean value' do
+    context 'On RedHat with PE set to a non-boolean value' do
       let :params do
         {
           :manage_configfile_symlink => 'invalid',
@@ -228,29 +411,72 @@ describe 'r10k::config' , :type => 'class' do
         expect { subject }.to raise_error(Puppet::Error)
       end
     end
+    context 'On OpenBSD with Puppet FOSS set to a non-boolean value' do
+      let :params do
+        {
+          :manage_configfile_symlink => 'invalid',
+          :configfile                => '/etc/r10k.yaml',
+          :cachedir                  => '/var/cache/r10k',
+          :manage_modulepath         => false,
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'OpenBSD',
+          :is_pe                  => 'false',
+        }
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(Puppet::Error)
+      end
+    end
   end
 
   describe 'with configfile_symlink specified as a non fully qualified path' do
-    let :params do
-      {
-        :manage_configfile_symlink => true,
-        :configfile                => '/etc/r10k.yaml',
-        :configfile_symlink        => 'invalid/path',
-        :cachedir                  => '/var/cache/r10k',
-        :manage_modulepath         => false,
-      }
-    end
-    let :facts do
-      {
-        :osfamily               => 'RedHat',
-        :operatingsystemrelease => '5',
-        :operatingsystem        => 'Centos',
-        :is_pe                  => 'true',
-      }
-    end
+    context 'On RedHat with PE' do
+      let :params do
+        {
+          :manage_configfile_symlink => true,
+          :configfile                => '/etc/r10k.yaml',
+          :configfile_symlink        => 'invalid/path',
+          :cachedir                  => '/var/cache/r10k',
+          :manage_modulepath         => false,
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '5',
+          :operatingsystem        => 'Centos',
+          :is_pe                  => 'true',
+        }
+      end
 
-    it 'should fail' do
-      expect { subject }.to raise_error(Puppet::Error)
+      it 'should fail' do
+        expect { subject }.to raise_error(Puppet::Error)
+      end
+    end
+    context 'On OpenBSD with Puppet FOSS' do
+      let :params do
+        {
+          :manage_configfile_symlink => true,
+          :configfile                => '/etc/r10k.yaml',
+          :configfile_symlink        => 'invalid/path',
+          :cachedir                  => '/var/cache/r10k',
+          :manage_modulepath         => false,
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'OpenBSD',
+          :is_pe                  => 'false',
+        }
+      end
+
+      it 'should fail' do
+        expect { subject }.to raise_error(Puppet::Error)
+      end
     end
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,12 +1,23 @@
 require 'spec_helper'
 describe 'r10k' do
-  context 'with default values for params' do
+  context 'On RedHat with PE with default values for params' do
     let :facts do
       {
         :osfamily               => 'RedHat',
         :operatingsystemrelease => '5',
         :operatingsystem        => 'Centos',
         :is_pe                  => 'true'
+      }
+    end
+    it { should compile.with_all_deps }
+    it { should_not contain_class('r10k::prerun_command') }
+    it { should_not contain_class('r10k::postrun_command') }
+  end
+  context 'On OpenBSD with Puppet FOSS with default values for params' do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false'
       }
     end
     it { should compile.with_all_deps }
@@ -21,7 +32,7 @@ describe 'r10k' do
   end
 
   ['true',true].each do |value|
-    context "with param include_prerun_command set to #{value}" do
+    context "On RedHat with PE with param include_prerun_command set to #{value}" do
       let(:params) { { :include_prerun_command => value } }
       let :facts do
         {
@@ -36,10 +47,23 @@ describe 'r10k' do
 
       it { should contain_class('r10k::prerun_command') }
     end
+    context "On OpenBSD with Puppet FOSS with param include_prerun_command set to #{value}" do
+      let(:params) { { :include_prerun_command => value } }
+      let :facts do
+        {
+          :osfamily               => 'OpenBSD',
+          :is_pe                  => 'false'
+        }
+      end
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('r10k::prerun_command') }
+    end
   end
 
   ['false',false].each do |value|
-    context "with param include_prerun_command set to #{value}" do
+    context "On RedHat with PE with param include_prerun_command set to #{value}" do
       let(:params) { { :include_prerun_command => value } }
       let :facts do
         {
@@ -54,10 +78,23 @@ describe 'r10k' do
 
       it { should_not contain_class('r10k::prerun_command') }
     end
+    context "On OpenBSD with Puppet FOSS with param include_prerun_command set to #{value}" do
+      let(:params) { { :include_prerun_command => value } }
+      let :facts do
+        {
+          :osfamily               => 'OpenBSD',
+          :is_pe                  => 'false'
+        }
+      end
+
+      it { should compile.with_all_deps }
+
+      it { should_not contain_class('r10k::prerun_command') }
+    end
   end
 
   ['true',true].each do |value|
-    context "with param include_postrun_command set to #{value}" do
+    context "On RedHat with PE with param include_postrun_command set to #{value}" do
       let(:params) { { :include_postrun_command => value } }
       let :facts do
         {
@@ -72,10 +109,23 @@ describe 'r10k' do
 
       it { should contain_class('r10k::postrun_command') }
     end
+    context "On OpenBSD with Puppet FOSS with param include_postrun_command set to #{value}" do
+      let(:params) { { :include_postrun_command => value } }
+      let :facts do
+        {
+          :osfamily               => 'OpenBSD',
+          :is_pe                  => 'false'
+        }
+      end
+
+      it { should compile.with_all_deps }
+
+      it { should contain_class('r10k::postrun_command') }
+    end
   end
 
   ['false',false].each do |value|
-    context "with param include_postrun_command set to #{value}" do
+    context "On RedHat with PE with param include_postrun_command set to #{value}" do
       let(:params) { { :include_postrun_command => value } }
       let :facts do
         {
@@ -83,6 +133,19 @@ describe 'r10k' do
           :operatingsystemrelease => '5',
           :operatingsystem        => 'Centos',
           :is_pe                  => 'true'
+        }
+      end
+
+      it { should compile.with_all_deps }
+
+      it { should_not contain_class('r10k::postrun_command') }
+    end
+    context "On OpenBSD with Puppet FOSS with param include_postrun_command set to #{value}" do
+      let(:params) { { :include_postrun_command => value } }
+      let :facts do
+        {
+          :osfamily               => 'OpenBSD',
+          :is_pe                  => 'false'
         }
       end
 

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -360,4 +360,23 @@ describe 'r10k::install' , :type => 'class' do
       )
     }
   end
+  context "On OpenBSD installing via packages" do
+    let :params do
+      {
+        :install_options        => '',
+        :keywords               => '',
+        :manage_ruby_dependency => 'declare',
+        :package_name           => 'ruby21-r10k',
+        :provider               => 'openbsd',
+        :version                => 'latest',
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+      }
+    end
+    it { should_not contain_class("git") }
+    it { should contain_package("ruby21-r10k")}
+  end
 end

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -15,4 +15,17 @@ describe 'r10k::params' , :type => 'class' do
       expect(subject.resources.size).to eq(4) 
     end
   end
+  context "Puppet FOSS on OpenBSD" do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false'
+      }
+    end
+    it { should contain_r10k__params }
+
+    it "Should not contain any resources" do
+      expect(subject.resources.size).to eq(4) 
+    end
+  end
 end

--- a/spec/classes/postrun_command_spec.rb
+++ b/spec/classes/postrun_command_spec.rb
@@ -1,45 +1,89 @@
 require 'spec_helper'
 describe 'r10k::postrun_command' , :type => 'class' do
-  let :facts do
-    {
-      :osfamily               => 'RedHat',
-      :operatingsystemrelease => '5',
-      :operatingsystem        => 'Centos',
-      :is_pe                  => 'true'
-    }
-  end
-  context "Puppet Enterprise on a RedHat 5 OS install adding custom postrun_command" do
-    let :params do
+  context 'Puppet Enterprise on a RedHat 5 OS install' do
+    let :facts do
       {
-        :command               => 'r10k synchronize',
-        :ensure                => 'present',
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true'
       }
     end
-    it { should contain_class("r10k::params") }
-    it { should contain_ini_setting("r10k_postrun_command").with(
-      'ensure'  => 'present',
-      'section' => 'agent',
-      'setting' => 'postrun_command',
-      'value'   => 'r10k synchronize',
-      'path'    => '/etc/puppetlabs/puppet/puppet.conf'
-    )
-    }
-  end
-  context "Puppet Enterprise on a RedHat 5 OS install removing custom postrun_command" do
-    let :params do
-      {
-        :command               => 'r10k synchronize',
-        :ensure                => 'absent',
+    context "adding custom postrun_command" do
+      let :params do
+        {
+          :command               => 'r10k synchronize',
+          :ensure                => 'present',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k synchronize',
+        'path'    => '/etc/puppetlabs/puppet/puppet.conf'
+      )
       }
     end
-    it { should contain_class("r10k::params") }
-    it { should contain_ini_setting("r10k_postrun_command").with(
-      'ensure'  => 'absent',
-      'section' => 'agent',
-      'setting' => 'postrun_command',
-      'value'   => 'r10k synchronize',
-      'path'    => '/etc/puppetlabs/puppet/puppet.conf'
-    )
-    }
+    context "removing custom postrun_command" do
+      let :params do
+        {
+          :command               => 'r10k synchronize',
+          :ensure                => 'absent',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'absent',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k synchronize',
+        'path'    => '/etc/puppetlabs/puppet/puppet.conf'
+      )
+      }
+    end
+  end
+  context 'Puppet FOSS on a OpenBSD install' do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false'
+      }
+    end
+    context "adding custom postrun_command" do
+      let :params do
+        {
+          :command               => 'r10k21 synchronize',
+          :ensure                => 'present',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k21 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+    context "removing custom postrun_command" do
+      let :params do
+        {
+          :command               => 'r10k21 synchronize',
+          :ensure                => 'absent',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'absent',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k21 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
   end
 end

--- a/spec/classes/prerun_command_spec.rb
+++ b/spec/classes/prerun_command_spec.rb
@@ -1,45 +1,89 @@
 require 'spec_helper'
 describe 'r10k::prerun_command' , :type => 'class' do
-  let :facts do
-    {
-      :osfamily               => 'RedHat',
-      :operatingsystemrelease => '5',
-      :operatingsystem        => 'Centos',
-      :is_pe                  => 'true'
-    }
-  end
-  context "Puppet Enterprise on a RedHat 5 OS install adding custom prerun_command" do
-    let :params do
+  context 'Puppet Enterprise on a RedHat 5 OS' do
+    let :facts do
       {
-        :command               => 'r10k synchronize',
-        :ensure                => 'present',
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true'
       }
     end
-    it { should contain_class("r10k::params") }
-    it { should contain_ini_setting("r10k_prerun_command").with(
-      'ensure'  => 'present',
-      'section' => 'agent',
-      'setting' => 'prerun_command',
-      'value'   => 'r10k synchronize',
-      'path'    => '/etc/puppetlabs/puppet/puppet.conf'
-    )
-    }
-  end
-  context "Puppet Enterprise on a RedHat 5 OS install removing custom prerun_command" do
-    let :params do
-      {
-        :command               => 'r10k synchronize',
-        :ensure                => 'absent',
+    context "adding custom prerun_command" do
+      let :params do
+        {
+          :command               => 'r10k synchronize',
+          :ensure                => 'present',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k synchronize',
+        'path'    => '/etc/puppetlabs/puppet/puppet.conf'
+      )
       }
     end
-    it { should contain_class("r10k::params") }
-    it { should contain_ini_setting("r10k_prerun_command").with(
-      'ensure'  => 'absent',
-      'section' => 'agent',
-      'setting' => 'prerun_command',
-      'value'   => 'r10k synchronize',
-      'path'    => '/etc/puppetlabs/puppet/puppet.conf'
-    )
-    }
+    context "removing custom prerun_command" do
+      let :params do
+        {
+          :command               => 'r10k synchronize',
+          :ensure                => 'absent',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'absent',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k synchronize',
+        'path'    => '/etc/puppetlabs/puppet/puppet.conf'
+      )
+      }
+    end
+  end
+  context 'Puppet FOSS on OpenBSD' do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :is_pe                  => 'false'
+      }
+    end
+    context "adding custom prerun_command" do
+      let :params do
+        {
+          :command               => 'r10k21 synchronize',
+          :ensure                => 'present',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k21 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+    context "removing custom prerun_command" do
+      let :params do
+        {
+          :command               => 'r10k21 synchronize',
+          :ensure                => 'absent',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'absent',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k21 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
   end
 end

--- a/spec/classes/r10k_spec.rb
+++ b/spec/classes/r10k_spec.rb
@@ -28,5 +28,31 @@ describe 'r10k' , :type => 'class' do
     end
     it { should contain_class('r10k::mcollective') }
   end
+  context "on OpenBSD" do
+    let :params do
+      { :remote => 'git@github.com:someuser/puppet.git' }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+      }
+    end
+    it { should contain_class('r10k::params') }
+    it { should contain_class('r10k::install') }
+    it { should contain_class('r10k::config') }
+    it { should_not contain_class('r10k::mcollective') }
+  end
+
+  context 'with mcollective' do
+    let(:params) do
+      { :mcollective => true }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+      }
+    end
+    it { should contain_class('r10k::mcollective') }
+  end
 end
 


### PR DESCRIPTION
  - Tested with OpenBSD -current, where there is a r10k package available
  - Ruby binaries on OpenBSD are prefixed with the Ruby version they are built
    for, therefore r10k is called r10k21, since that is the version Puppet
    and r10k relies on
    - that would also be the case if r10k would be installed with the 'gem'
      package provider
  - the service name of mcollective is called 'mcollectived' on OpenBSD

Because of the last two mentioned points, added an osfamily dependent
 r10k_binary variable, as well as making the mc_service_name variable
osfamily dependent too.

What I tested was managing the installation of package and configuration
file /etc/r10k.yaml as well as the prerun script added to /etc/puppet/puppet.conf
file. Pre-run script comes in handy, since my modules/hieradata is on
a ram disk, and on boot, it auto-fills itself before a first puppet agent
run on the master.

Not tested is the mcollective integration, since I first have to
clean up my messed up mcollective setup. That's something that
would come later.

Let me know if there is something to add/fix/rework etc.