### PR TITLE
Fix for #165

### DIFF
--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -7,7 +7,8 @@ class r10k::mcollective (
   $app_path          = $r10k::params::mc_application_path,
   $mc_service        = $r10k::params::mc_service_name,
   $http_proxy        = $r10k::params::mc_http_proxy,
-  $git_ssl_verify    = $r10k::params::mc_git_ssl_verify,
+  $git_ssl_verify    = $r10k::params::mc_git_ssl_verify, # Deprecated
+  $git_ssl_no_verify = $r10k::params::mc_git_ssl_no_verify,
 ) inherits r10k::params {
   File {
     ensure => present,
@@ -15,6 +16,14 @@ class r10k::mcollective (
     group  => '0',
     mode   => '0644',
   }
+
+  if $git_ssl_verify {
+    warning('$git_ssl_verify parameter is deprecated, please use $git_ssl_no_verify instead')
+    $agent_no_verify = $git_ssl_verify
+  } else {
+    $agent_no_verify = $git_ssl_no_verify
+  }
+
   # Install the agent and its ddl file
   file { "${app_path}/${app_name}":
     source => "puppet:///modules/${module_name}/application/${agent_name}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -123,7 +123,8 @@ class r10k::params
   $mc_agent_path       = "${plugins_dir}/agent"
   $mc_application_path = "${plugins_dir}/application"
   $mc_http_proxy       = undef
-  $mc_git_ssl_verify   = 0
+  $mc_git_ssl_verify    = undef # Deprecated parameter - Renamed to $mc_git_ssl_no_verify for clarity
+  $mc_git_ssl_no_verify = 0
 
   # Service Settings for SystemD in EL7
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -33,7 +33,59 @@ describe 'r10k::mcollective' , :type => 'class' do
       )
     }
 
+    it {
+      should contain_file("/opt/puppet/libexec/mcollective/mcollective/agent/r10k.rb").
+        with_content(/\"GIT_SSL_NO_VERIFY\" => \"0\"/)
+    }
+
   end
+
+  context "Allows you to set git_ssl_no_verify for r10k file" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true'
+      }
+    end
+
+    let :params do
+      {
+        :git_ssl_no_verify => 1,
+      }
+    end
+
+    it {
+      should contain_file("/opt/puppet/libexec/mcollective/mcollective/agent/r10k.rb").
+        with_content(/\"GIT_SSL_NO_VERIFY\" => \"1\"/)
+    }
+
+  end
+
+    context "Allows you to set git_ssl_verify for r10k file (deprecated - to be removed in major bump)" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true'
+      }
+    end
+
+    let :params do
+      {
+        :git_ssl_verify => 1,
+      }
+    end
+
+    it {
+      should contain_file("/opt/puppet/libexec/mcollective/mcollective/agent/r10k.rb").
+        with_content(/\"GIT_SSL_NO_VERIFY\" => \"1\"/)
+    }
+
+  end
+
   context "Puppet FOSS on a RedHat 5 OS installing mcollective agent & application" do
     let :facts do
       {

--- a/templates/agent/r10k.rb.erb
+++ b/templates/agent/r10k.rb.erb
@@ -56,7 +56,7 @@ module MCollective
         git  = ['/usr/bin/env', 'git']
         r10k = ['/usr/bin/env', 'r10k']
         # Given most people using this are using Puppet Enterprise, add the PE Path
-        environment = {"LC_ALL" => "C","PATH" => "#{ENV['PATH']}:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>", "http_proxy" => "<%= @http_proxy %>", "https_proxy" => "<%= @http_proxy %>", "GIT_SSL_NO_VERIFY" => "<%= @git_ssl_verify %>" }
+        environment = {"LC_ALL" => "C","PATH" => "#{ENV['PATH']}:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>", "http_proxy" => "<%= @http_proxy %>", "https_proxy" => "<%= @http_proxy %>", "GIT_SSL_NO_VERIFY" => "<%= @agent_no_verify %>" }
         case action
           when 'push','pull','status'
             cmd = git


### PR DESCRIPTION
```
The parameter is git_ssl_verify but the value it's setting is GIT_SSL_NO_VERIFY

So git_ssl_verify => 'true' is actually saying "Make sure SSL is not verified"

Probably better to rename it to git_no_ssl_verify and add a deprecation to the old parameter, followed by removal in a major bump?
```