### PR TITLE
improve the webhook systemd unit file

### DIFF
--- a/templates/webhook.service.erb
+++ b/templates/webhook.service.erb
@@ -3,17 +3,10 @@ Description=R10K Webhook Service
 After=syslog.target network.target
 
 [Service]
-Type=simple
-EnvironmentFile=/etc/sysconfig/webhook
+Type=forking
 User=<%= @user %>
-TimeoutStartSec=90
-TimeoutStopSec=30
-
 ExecStart=/usr/local/bin/webhook
-
-KillMode=process
-
-StandardOutput=syslog
+PIDFile=/var/run/webhook/webhook.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Type=forking as webrick fails to start otherwise
- PIDFile=$pidfile otherwise it fails to auto-detect it, and fails to stop the
  service
- Removing the rest of the variables as they are not really needed, or their
  default values are sufficient