### PR TITLE
change config location for version > 1.5.0

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -79,6 +79,17 @@ class r10k::config (
     $source_keys = keys($r10k_sources)
   }
 
+  if $configfile == '/etc/puppetlabs/r10k/r10k.yaml' {
+    file {['/etc/puppetlabs', '/etc/puppetlabs/r10k']:
+      ensure => directory,
+      before => File['r10k.yaml'],
+    }
+
+    file {'/etc/r10k.yaml':
+      ensure => absent,
+    }
+  }
+
   file { 'r10k.yaml':
     ensure  => file,
     owner   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,11 @@ class r10k::params
   $sources                = undef
 
   # r10k configuration
-  $r10k_config_file          = '/etc/r10k.yaml'
+  if versioncmp($version, '1.5.0') >= 0 {
+    $r10k_config_file          = '/etc/puppetlabs/r10k/r10k.yaml'
+  } else {
+    $r10k_config_file          = '/etc/r10k.yaml'
+  }
   $r10k_cache_dir            = '/var/cache/r10k'
   $r10k_basedir              = "${::settings::confdir}/environments"
   $manage_configfile_symlink = false


### PR DESCRIPTION
R10K is released and removes /etc/r10k.yaml from the default search
path: https://tickets.puppetlabs.com/browse/RK-53

Change the config location to /etc/puppetlabs/r10k/r10k.yaml if veersion
is >= 1.5.0 and make sure directories are present. Also remove
/etc/r10k.yaml

fixes: #190