### PR TITLE
188 - Webhook segfault on status

### DIFF
--- a/templates/webhook.init.erb
+++ b/templates/webhook.init.erb
@@ -53,14 +53,14 @@ restart() {
     start
 }
 
-status() {
+whstatus() {
     if [ -f "${pidfile}" ]; then
     <% if @osfamily == 'Debian' -%>
         status_of_proc -p $pidfile $webhook
     <% elsif @osfamily == 'SUSE' -%>
         checkproc -k -p $pidfile $webhook
     <% else -%>
-        status -p $pidfile $webhook
+        status $webhook $pidfile
     <% end -%>
         RETVAL=$?
     else
@@ -81,7 +81,7 @@ case "$1" in
         restart
     ;;
     status)
-        status
+        whstatus
     ;;
     *)
         echo $"Usage: $0 {start|stop|status|restart}"

--- a/templates/webhook.init.erb
+++ b/templates/webhook.init.erb
@@ -60,7 +60,7 @@ whstatus() {
     <% elsif @osfamily == 'SUSE' -%>
         checkproc -k -p $pidfile $webhook
     <% else -%>
-        status $webhook $pidfile
+        status -p $pidfile $webhook
     <% end -%>
         RETVAL=$?
     else


### PR DESCRIPTION
Addresses issue 188

When not debian or SUSE, the call to the status function is invalid.

Fixed the ordering of the status call to
status $webhook $pidfile

Also, collision between the internal status function and the status
fucntion within /etc/init.d/functions. Because of this segfault was
occurring. Renamed internal function to whstatus.