### PR TITLE
Restore EnvironmentFile line as optional

### DIFF
--- a/templates/webhook.service.erb
+++ b/templates/webhook.service.erb
@@ -4,6 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=forking
+EnvironmentFile=-/etc/sysconfig/webhook
 User=<%= @user %>
 ExecStart=/usr/local/bin/webhook
 PIDFile=/var/run/webhook/webhook.pid


### PR DESCRIPTION
Fixes #197 by restoring the EnvironmentFile line as option. See below for documentation on unit files.

https://fedoraproject.org/wiki/Packaging%3aSystemd#EnvironmentFiles_and_support_for_.2Fetc.2Fsysconfig_files