### PR TITLE
Contributing a working (CentOS7 + PE 3.8.1) systemd service script fo…

### DIFF
--- a/templates/webhook.service.erb
+++ b/templates/webhook.service.erb
@@ -3,11 +3,16 @@ Description=R10K Webhook Service
 After=syslog.target network.target
 
 [Service]
-Type=forking
-EnvironmentFile=-/etc/sysconfig/webhook
+Type=simple
 User=<%= @user %>
+TimeoutStartSec=90
+TimeoutStopSec=30
+
 ExecStart=/usr/local/bin/webhook
-PIDFile=/var/run/webhook/webhook.pid
+
+KillMode=process
+
+StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…r evaluation.

I was trying to get the webhook working over CentOS 7.  By utilizing tom's contributions, what Zack already had in the pipe, and then some systemd documentation, I was able to get a systemctl script that starts the webhook daemon every time.  I cannot seem to get control over the process to kill, however, and could certainly use some help on that.