### PR TITLE
Service <| title == $mc_service |> causes catalog error

### DIFF
--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -39,7 +39,7 @@ class r10k::mcollective (
     require => File["${agent_path}/${agent_ddl}"],
   }
 
-  Service <| title == $mc_service |> {
+  Service <| name == $mc_service |> {
     subscribe +> [ File["${app_path}/${app_name}"], File["${agent_path}/${agent_ddl}"] ],
   }
 }


### PR DESCRIPTION
[vagrant@puppetmaster ~]$ puppet --version
3.8.1
[vagrant@puppetmaster ~]$ ruby -v
ruby 1.8.7 (2013-06-27 patchlevel 374) [x86_64-linux]

Stderr from the command:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator,
 [no address given] and inform them of the time the error occurred,
and anything you might have done that may have
caused the error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

which get fixed using this change