### PR TITLE
Add EnvironmentFile line as optional

### DIFF
--- a/templates/webhook.rehat.service.erb
+++ b/templates/webhook.rehat.service.erb
@@ -4,6 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/sysconfig/webhook
 User=<%= @user %>
 TimeoutStartSec=90
 TimeoutStopSec=30


### PR DESCRIPTION
Resolves #197 again (but with the original unit file). @acidprime I don't have any strong feelings about the unit file except for keeping this line. Given that it is optional, it really shouldn't cause any problems unless they have the file created but with incorrect options.