### PR TITLE
Add postrun to r10k.yaml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,10 @@
 # * [*sources*]
 #   Hash containing data sources to be used by r10k to create dynamic Puppet
 #   environments. Default: {}
+# * [*postrun*]
+#   **Optional:** Array containing the parts of a system call. 
+#   Example: ['/usr/bin/curl', '-F', 'deploy=done', 'http://my-app.site/endpoint']
+#   Default: undef
 # * [*manage_configfile_symlink*]
 #   Boolean to determine if a symlink to the r10k config file is to be managed.
 #   Default: false
@@ -46,6 +50,7 @@ class r10k::config (
   $modulepath                = undef,
   $remote                    = '',
   $sources                   = 'UNSET',
+  $postrun                   = undef,
   $puppetconf_path           = $r10k::params::puppetconf_path,
   $r10k_basedir              = $r10k::params::r10k_basedir,
   $manage_configfile_symlink = $r10k::params::manage_configfile_symlink,
@@ -77,6 +82,10 @@ class r10k::config (
 
     $r10k_sources = $sources
     $source_keys = keys($r10k_sources)
+  }
+
+  if $postrun != undef {
+    validate_array($postrun)
   }
 
   file { 'r10k.yaml':

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -479,4 +479,46 @@ describe 'r10k::config' , :type => 'class' do
       end
     end
   end
+
+  describe 'with optional parameter postrun specified' do
+    context 'with array of system call "/usr/bin/curl -F deploy=done http://my-app.site/endpoint"' do
+      let :params do
+        {
+          :configfile        => '/etc/r10k.yaml',
+          :cachedir          => '/var/cache/r10k',
+          :manage_modulepath => false,
+          :postrun           => ['/usr/bin/curl', '-F', 'deploy=done', 'http://my-app.site/endpoint'],
+        }
+      end
+      it { should contain_file('r10k.yaml').with_content(/^:postrun: \[\"\/usr\/bin\/curl\", \"-F\", \"deploy=done\", \"http:\/\/my-app\.site\/endpoint\"\]$/) }
+    end
+
+    context 'with postrun left undefined' do
+      let :params do
+        {
+          :configfile        => '/etc/r10k.yaml',
+          :cachedir          => '/var/cache/r10k',
+          :manage_modulepath => false,
+        }
+      end
+      it { should contain_file('r10k.yaml').without_content(/^:postrun: .*$/) }
+    end
+
+    ['string', true, 1, 1.0, {}].each do |value|
+      context "with #{value}" do
+        let :params do
+          {
+            :configfile        => '/etc/r10k.yaml',
+            :cachedir          => '/var/cache/r10k',
+            :manage_modulepath => false,
+            :postrun           => value,
+          }
+        end
+        
+        it 'should fail when sources is not an Array' do
+          expect { subject }.to raise_error(Puppet::Error, /is not an Array/)
+        end
+      end
+    end
+  end
 end

--- a/templates/r10k.yaml.erb
+++ b/templates/r10k.yaml.erb
@@ -1,3 +1,7 @@
+---
+<% if @postrun and @postrun.is_a?(Array) -%>
+:postrun: <%= @postrun %>
+<% end -%>
 :cachedir: <%= @cachedir %>
 <% unless @r10k_sources.empty? -%>
 :sources:


### PR DESCRIPTION
Fixes #211.

This simply adds the `postrun` r10k configuration option to `r10k.yaml`.

You can choose a script for yourself, maybe provided by a profile etc.