### PR TITLE
Changes in r10k::webhook class

### DIFF
--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -49,7 +49,7 @@ class r10k::webhook(
   }
 
   if $manage_packages {
-    include webhook::package
+    include r10k::webhook::package
   }
 
   if $::is_pe == true or $::is_pe == 'true' {


### PR DESCRIPTION
Include r10k::webhook::package by using full class path.
This allows to run this code on Puppet 4.x

Fixes #213