### PR TITLE
Don't set ENV['HOME'] inside webhook

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -28,7 +28,6 @@ else
   raise "Configuration file: #{WEBHOOK_CONFIG} does not exist"
 end
 
-ENV['HOME'] = '/var/lib/<%= @user %>'
 ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>'
 
 $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)


### PR DESCRIPTION
Don't set ENV['HOME'] inside webhook, and let the application inherit from the user it is running at.

By setting HOME it causes the application to cause an error whenever the users home is not located in /var/lib. Some more information bellow:

/var/log/webhook/access.log:
<pre>
[2015-07-08 19:12:39] DEBUG Rack::Handler::WEBrick is mounted on /.
[2015-07-08 19:12:39] INFO  WEBrick::HTTPServer#start: pid=16933 port=8088
[2015-07-08 19:13:26] DEBUG accept: 127.0.0.1:45979
[2015-07-08 19:13:26] DEBUG Rack::Handler::WEBrick is invoked.
[2015-07-08 19:13:26] INFO  authenticated: puppet
[2015-07-08 19:13:26] ERROR message: 
/usr/share/rubygems/rubygems/path_support.rb:68:in `path=': undefined method `+' for nil:NilClass (NoMethodError)
        from /usr/share/rubygems/rubygems/path_support.rb:30:in `initialize'
        from /usr/share/rubygems/rubygems.rb:357:in `new'
        from /usr/share/rubygems/rubygems.rb:357:in `paths'
        from /usr/share/rubygems/rubygems.rb:379:in `path'
        from /usr/share/rubygems/rubygems/specification.rb:794:in `dirs'
        from /usr/share/rubygems/rubygems/specification.rb:658:in `each_normal'
        from /usr/share/rubygems/rubygems/specification.rb:669:in `_all'
        from /usr/share/rubygems/rubygems/specification.rb:822:in `each'
        from /usr/share/rubygems/rubygems/specification.rb:864:in `find'
        from /usr/share/rubygems/rubygems/specification.rb:864:in `find_inactive_by_path'
        from /usr/share/rubygems/rubygems.rb:175:in `try_activate'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:132:in `rescue in require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:144:in `require'
        from <internal:abrt_prelude>:2:in `<compiled>'
 trace: ["/usr/local/bin/webhook:168:in `deploy'", "/usr/local/bin/webhook:121:in `block in <class:Server>'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `call'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1610:in `block in compile!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `[]'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (3 levels) in route!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:993:in `route_eval'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:974:in `block (2 levels) in route!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1014:in `block in process_route'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `catch'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1012:in `process_route'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:972:in `block in route!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `each'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:971:in `route!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1084:in `block in dispatch!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1081:in `dispatch!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `block in call!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `block in invoke'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `catch'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1066:in `invoke'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:906:in `call!'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:894:in `call'", "/usr/local/share/gems/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'", "/usr/local/share/gems/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'", "/usr/local/share/gems/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'", "/usr/local/share/gems/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'", "/usr/local/share/gems/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'", "/usr/local/share/gems/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'", "/usr/local/share/gems/gems/rack-1.6.4/lib/rack/nulllogger.rb:9:in `call'", "/usr/local/share/gems/gems/rack-1.6.4/lib/rack/head.rb:13:in `call'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/show_exceptions.rb:21:in `call'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:181:in `call'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:2021:in `call'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `block in call'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1795:in `synchronize'", "/usr/local/share/gems/gems/sinatra-1.4.6/lib/sinatra/base.rb:1486:in `call'", "/usr/local/share/gems/gems/rack-1.6.4/lib/rack/handler/webrick.rb:88:in `service'", "/usr/share/ruby/webrick/httpserver.rb:138:in `service'", "/usr/share/ruby/webrick/httpserver.rb:94:in `run'", "/usr/share/ruby/webrick/server.rb:295:in `block in start_thread'"]
[2015-07-08 19:13:26] DEBUG close: 127.0.0.1:45979
</pre>


A snipped from a strace:
<pre>
lstat("/usr/share", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/usr/share/rubygems", {st_mode=S_IFDIR|0755, st_size=71, ...}) = 0
lstat("/usr/share/rubygems/rubygems", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("/usr/share/rubygems/rubygems/path_support.rb", {st_mode=S_IFREG|0644, st_size=1623, ...}) = 0
getuid()                                = 0
stat("/var/lib/root", 0x7ffd2249f880)   = -1 ENOENT (No such file or directory)
write(2, "/usr/share/rubygems/rubygems/pat"..., 58) = 58
write(2, ": ", 2)                       = 2
write(2, "undefined method `+' for nil:Nil"..., 37) = 37
write(2, " (", 2)                       = 2
write(2, "NoMethodError", 13)           = 13
write(2, ")\n", 2)                      = 2
</pre>