### PR TITLE
(METHOD-401) Fix Webhook Service on EL7

### DIFF
--- a/templates/webhook.rehat.service.erb
+++ b/templates/webhook.rehat.service.erb
@@ -3,11 +3,13 @@ Description=R10K Webhook Service
 After=syslog.target network.target
 
 [Service]
-Type=simple
+Type=forking
 EnvironmentFile=-/etc/sysconfig/webhook
 User=<%= @user %>
+PIDFile=/var/run/webhook/webhook.pid
 TimeoutStartSec=90
 TimeoutStopSec=30
+RestartSec=10000
 
 ExecStart=/usr/local/bin/webhook
 


### PR DESCRIPTION
Previously, the webhook process was not terminated by systemd when
stopping the service. This caused reloading of the service to raise a
socket collision error due to the persistence of the old process.

This commit makes the appropriate systemd configuration changes to
facilitate stopping/restarting of the service.