### PR TITLE
Allow module to work with PE 3.8.x Razor (no master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ class { 'r10k':
 }
 ```
 _Note: On Puppet Enterprise 3.8 and higher the package is not declared as 3.8
-ships with an embdedded r10k gem installed via the PE packages_
+ships with an embdedded r10k gem installed via the PE packages. To install r10k on a PE 3.8+ non-master, set puppet_master to false for the main r10k class (e.g. to use r10k with Razor)_
 
 ## Usage
 
@@ -415,7 +415,8 @@ git_webhook { 'web_post_receive_webhook_for_module' :
 ### Running without mcollective
 If you have only a single master, you may want to have the webhook run r10k directly rather then
 as peadmin via mcollective. This requires you to run as the user that can perform `r10k` commands
-which is typically root.
+which is typically root. The peadmin certificate no longer is managed or required.
+
 
 ```puppet
 # Instead of running via mco, run r10k directly
@@ -427,9 +428,10 @@ class {'r10k::webhook::config':
 # It will issue r10k deploy environment <branch_from_gitlab_payload> -p
 # When git pushes happen.
 class {'r10k::webhook':
-  user    => 'root',
-  group   => '0',
-  require => Class['r10k::webhook::config'],
+  use_mcollective => false,
+  user            => 'root',
+  group           => '0',
+  require         => Class['r10k::webhook::config'],
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class r10k (
   $cachedir                  = $r10k::params::r10k_cache_dir,
   $configfile                = $r10k::params::r10k_config_file,
   $version                   = $r10k::params::version,
+  $puppet_master             = $r10k::params::puppet_master,
   $modulepath                = $r10k::params::modulepath,
   $manage_modulepath         = $r10k::params::manage_modulepath,
   $manage_ruby_dependency    = $r10k::params::manage_ruby_dependency,
@@ -40,6 +41,7 @@ class r10k (
     package_name           => $package_name,
     provider               => $provider,
     version                => $version,
+    puppet_master          => $puppet_master,
   }
 
   class { 'r10k::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,6 +6,7 @@ class r10k::install (
   $keywords,
   $install_options,
   $manage_ruby_dependency,
+  $puppet_master,
 ) {
 
   # There are currently bugs in r10k 1.x which make using 0.x desireable in
@@ -48,9 +49,10 @@ class r10k::install (
         }
       }
       elsif $provider == 'pe_gem' {
-        include r10k::install::pe_gem
+        class { 'r10k::install::pe_gem':
+          puppet_master => $puppet_master,
+        }
       }
-
 
       # Currently we share a package resource to keep things simple
       # Puppet seems to have a bug (see #87 ) related to passing an
@@ -64,8 +66,8 @@ class r10k::install (
       }
 
       # Puppet Enterprise 3.8 and ships an embedded r10k so thats all thats supported
-      # This conditional should not effect FOSS customers based on the fact 
-      unless ($::is_pe == 'true' or $::is_pe == true) and versioncmp($::pe_version, '3.8.0') >= 0 {
+      # This conditional should not effect FOSS customers based on the fact
+      unless ($::is_pe == 'true' or $::is_pe == true) and versioncmp($::pe_version, '3.8.0') >= 0 and $puppet_master {
         package { $real_package_name:
           ensure          => $version,
           provider        => $provider,

--- a/manifests/install/pe_gem.pp
+++ b/manifests/install/pe_gem.pp
@@ -1,11 +1,13 @@
 # This class links the r10k binary for PE
-class r10k::install::pe_gem {
+class r10k::install::pe_gem (
+  $puppet_master,
+) {
 
   require git
 
   # Puppet Enterprise 3.8 ships code to manage this symlink on install
   # This conditional should not effect FOSS customers based on the fact
-  unless versioncmp($::pe_version, '3.8.0') >= 0 {
+  unless versioncmp($::pe_version, '3.8.0') >= 0 and $puppet_master {
     file { '/usr/bin/r10k':
       ensure  => link,
       target  => '/opt/puppet/bin/r10k',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class r10k::params
   $manage_ruby_dependency = 'declare'
   $install_options        = []
   $sources                = undef
+  $puppet_master          = true
 
   # r10k configuration
   $r10k_config_file          = '/etc/r10k.yaml'

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -5,6 +5,7 @@ class r10k::webhook(
   $bin_template     = $r10k::params::webhook_bin_template,
   $service_template = $r10k::params::webhook_service_template,
   $service_file     = $r10k::params::webhook_service_file,
+  $use_mcollective  = $r10k::params::webhook_use_mcollective,
   $manage_packages  = true,
 ) inherits r10k::params {
 
@@ -52,11 +53,12 @@ class r10k::webhook(
     include r10k::webhook::package
   }
 
-  if $::is_pe == true or $::is_pe == 'true' {
-    if versioncmp($::pe_version, '3.7.0') >= 0 {
-      # 3.7 does not place the certificate in peadmin's ~
-      # This places it there as if it was an upgrade
-      file { 'peadmin-cert.pem':
+  if $use_mcollective == true {
+    if $::is_pe == true or $::is_pe == 'true' {
+      if versioncmp($::pe_version, '3.7.0') >= 0 {
+        # 3.7 does not place the certificate in peadmin's ~
+        # This places it there as if it was an upgrade
+        file { 'peadmin-cert.pem':
           ensure  => 'file',
           path    => '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem',
           owner   => 'peadmin',
@@ -64,6 +66,7 @@ class r10k::webhook(
           mode    => '0644',
           content => file('/etc/puppetlabs/puppet/ssl/certs/pe-internal-peadmin-mcollective-client.pem','/dev/null'),
           notify  => Service['webhook'],
+        }
       }
     }
   }

--- a/spec/classes/install/pe_gem_spec.rb
+++ b/spec/classes/install/pe_gem_spec.rb
@@ -1,12 +1,62 @@
 require 'spec_helper'
 describe 'r10k::install::pe_gem' , :type => 'class' do
-  context "on a RedHat 5 OS installing 1.1.0 via pe_gem for Puppet Enterprise" do
+  context "on a RedHat 5 OS installing 1.1.0 via pe_gem for Puppet Enterprise 3.7.1" do
+    let :params do
+      {
+        :puppet_master => true,
+      }
+    end
     let :facts do
       {
         :osfamily               => 'RedHat',
         :puppetversion          => '2.7.19',
         :operatingsystemrelease => '5',
-        :is_pe                  => 'true'
+        :is_pe                  => 'true',
+        :pe_version             => '3.7.1'
+      }
+    end
+    it { should contain_file("/usr/bin/r10k").with(
+        'ensure'  => 'link',
+        'target'  => '/opt/puppet/bin/r10k',
+        'require' => 'Package[r10k]'
+      )
+    }
+  end
+  context "on a RedHat 5 OS installing 1.1.0 via pe_gem for Puppet Enterprise 3.8.1" do
+    let :params do
+      {
+        :puppet_master => true,
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :puppetversion          => '2.7.19',
+        :operatingsystemrelease => '5',
+        :is_pe                  => 'true',
+        :pe_version             => '3.8.1'
+      }
+    end
+    it { should_not contain_file("/usr/bin/r10k").with(
+        'ensure'  => 'link',
+        'target'  => '/opt/puppet/bin/r10k',
+        'require' => 'Package[r10k]'
+      )
+    }
+  end
+  context "on a RedHat 5 OS installing 1.1.0 via pe_gem for Puppet Enterprise 3.8.1 not puppet master" do
+    let :params do
+      {
+        :puppet_master => false,
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :puppetversion          => '2.7.19',
+        :operatingsystemrelease => '5',
+        :is_pe                  => 'true',
+        :pe_version             => '3.8.1'
       }
     end
     it { should contain_file("/usr/bin/r10k").with(

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -9,6 +9,7 @@ describe 'r10k::install' , :type => 'class' do
         :package_name           => 'r10k',
         :provider               => 'gem',
         :version                => '1.1.0',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -42,6 +43,7 @@ describe 'r10k::install' , :type => 'class' do
         :package_name           => 'r10k',
         :provider               => 'gem',
         :version                => '0.0.9',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -76,6 +78,7 @@ describe 'r10k::install' , :type => 'class' do
         :keywords               => '',
         :manage_ruby_dependency => 'declare',
         :install_options        => '',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -101,6 +104,7 @@ describe 'r10k::install' , :type => 'class' do
         :manage_ruby_dependency => 'declare',
         :keywords               => '',
         :install_options        => '',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -122,6 +126,7 @@ describe 'r10k::install' , :type => 'class' do
         :package_name           => 'rubygem-r10k',
         :provider               => 'yum',
         :version                => 'latest',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -142,6 +147,7 @@ describe 'r10k::install' , :type => 'class' do
         :package_name           => 'r10k',
         :provider               => 'zypper',
         :version                => 'latest',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -162,6 +168,7 @@ describe 'r10k::install' , :type => 'class' do
         :package_name           => 'app-admin/r10k',
         :provider               => 'portage',
         :version                => '1.1.0',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -200,6 +207,7 @@ describe 'r10k::install' , :type => 'class' do
         :provider               => 'pe_gem',
         :version                => '1.1.0',
         :keywords               => '',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -225,6 +233,39 @@ describe 'r10k::install' , :type => 'class' do
     }
 
   end
+  context "Puppet Enterprise 3.8.x on a RedHat 5 installing via pe_gem not a master" do
+    let :params do
+      {
+        :manage_ruby_dependency => 'declare',
+        :install_options        => '',
+        :package_name           => 'r10k',
+        :provider               => 'pe_gem',
+        :version                => '1.1.0',
+        :keywords               => '',
+        :puppet_master          => false,
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => true,
+        :pe_version             => '3.8.1'
+      }
+    end
+    it { should contain_package("r10k").with(
+        :ensure     => '1.1.0',
+        :provider   => 'pe_gem'
+      )
+    }
+    it { should contain_file("/usr/bin/r10k").with(
+        'ensure'  => 'link',
+        'target'  => '/opt/puppet/bin/r10k',
+        'require' => 'Package[r10k]'
+      )
+    }
+  end
   context "Puppet Enterprise 3.7.x on a RedHat 5 installing via pe_gem" do
     let :params do
       {
@@ -234,6 +275,7 @@ describe 'r10k::install' , :type => 'class' do
         :provider               => 'pe_gem',
         :version                => '1.1.0',
         :keywords               => '',
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -266,6 +308,7 @@ describe 'r10k::install' , :type => 'class' do
         :version                => '1.5.0',
         :keywords               => '',
         :install_options        => [],
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -294,6 +337,7 @@ describe 'r10k::install' , :type => 'class' do
         :version                => '1.5.0',
         :keywords               => '',
         :install_options        => [],
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -319,6 +363,7 @@ describe 'r10k::install' , :type => 'class' do
         :version                => '1.5.0',
         :keywords               => '',
         :install_options        => ['BOGON'],
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -344,6 +389,7 @@ describe 'r10k::install' , :type => 'class' do
         :version                => '1.5.0',
         :keywords               => '',
         :install_options        => ['BOGON'],
+        :puppet_master          => true,
       }
     end
     let :facts do
@@ -369,6 +415,7 @@ describe 'r10k::install' , :type => 'class' do
         :package_name           => 'ruby21-r10k',
         :provider               => 'openbsd',
         :version                => 'latest',
+        :puppet_master          => true,
       }
     end
     let :facts do

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 describe 'r10k::webhook' , :type => 'class' do
   context 'Puppet Enterprise 3.7.0 on a RedHat 5 installing webhook' do
+    let :params do
+      {
+        :use_mcollective => true,
+      }
+    end
     let :facts do
       {
         :osfamily               => 'RedHat',
@@ -27,6 +32,37 @@ describe 'r10k::webhook' , :type => 'class' do
         'owner'   => 'peadmin',
         'group'   => 'peadmin',
         'mode'    => '0644'
+      )
+    }
+  end
+  context 'Puppet Enterprise 3.7.0 on a RedHat 5 installing webhook no mco' do
+    let :params do
+      {
+        :use_mcollective => false,
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true',
+        :pe_version             => '3.7.0'
+      }
+    end
+    it { should contain_package('sinatra').with(
+        'ensure'   => 'installed',
+        'provider' => 'pe_gem'
+      )
+    }
+
+    it { should contain_package('sinatra').with(
+        'ensure'    => 'installed',
+        'provider'  => 'pe_gem'
+      )
+    }
+    it { should_not contain_file('peadmin-cert.pem').with(
+        'path'   => '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem'
       )
     }
   end


### PR DESCRIPTION
 - Only manage the peadmin cert if use_mcollective is true
 - Allow r10k to be installed for PE 3.8+ if puppet_master is set to false
 - Update rspec and readme