### PR TITLE
Use included ruby and gem for Puppet FOSS 4.2.0

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,6 +47,11 @@ class r10k::install (
           version                => $version;
         }
       }
+      elsif $provider == 'puppet_gem' {
+        # Puppet FOSS 4.2 and up ships a vendor provided ruby.
+        # Using puppet_gem uses that instead of the system ruby.
+        include r10k::install::puppet_gem
+      }
       elsif $provider == 'pe_gem' {
         include r10k::install::pe_gem
       }
@@ -72,6 +77,7 @@ class r10k::install (
           install_options => $provider_install_options
         }
       }
+
     }
     default: { fail("${module_name}: ${provider} is not supported. Valid values are: 'gem', 'pe_gem', 'puppet_gem', 'bundle', 'openbsd', 'portage', 'yum', 'zypper'") }
   }

--- a/manifests/install/puppet_gem.pp
+++ b/manifests/install/puppet_gem.pp
@@ -6,7 +6,7 @@ class r10k::install::puppet_gem {
   unless versioncmp($::puppetversion, '4.2.0') >= 0 {
     file { '/usr/bin/r10k':
       ensure  => link,
-      target  => '/opt/puppetlabs/bin/r10k',
+      target  => '/opt/puppetlabs/puppet/bin/r10k',
       require => Package['r10k'],
     }
   }

--- a/manifests/install/puppet_gem.pp
+++ b/manifests/install/puppet_gem.pp
@@ -1,0 +1,13 @@
+# This class links the r10k binary for Puppet FOSS 4.2 and up
+class r10k::install::puppet_gem {
+
+  require git
+
+  unless versioncmp($::puppetversion, '4.2.0') >= 0 {
+    file { '/usr/bin/r10k':
+      ensure  => link,
+      target  => '/opt/puppetlabs/bin/r10k',
+      require => Package['r10k'],
+    }
+  }
+}

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -20,10 +20,19 @@ class r10k::webhook::package {
       }
     }
   } else {
+
+    # Puppet FOSS 4.2 and up ships a vendor provided ruby.
+    # Using puppet_gem uses that instead of the system ruby.
+    if (versioncmp($::puppetversion, '4.2.0') >= 0) {
+      $provider = 'puppet_gem'
+    } else {
+      $provider = 'gem'
+    }
+
     if !defined(Package['webrick']) {
       package { 'webrick':
         ensure   => installed,
-        provider => 'gem',
+        provider => $provider,
         before   => Service['webhook'],
       }
     }
@@ -31,7 +40,7 @@ class r10k::webhook::package {
     if !defined(Package['json']) {
       package { 'json':
         ensure   => installed,
-        provider => 'gem',
+        provider => $provider,
         before   => Service['webhook'],
       }
     }
@@ -39,7 +48,7 @@ class r10k::webhook::package {
     if !defined(Package['sinatra']) {
       package { 'sinatra':
         ensure   => installed,
-        provider => 'gem',
+        provider => $provider,
         before   => [
           Service['webhook'],
           File['webhook_init_script'],
@@ -51,7 +60,7 @@ class r10k::webhook::package {
       if !defined(Package['rack']) {
         package { 'rack':
           ensure   => installed,
-          provider => 'gem',
+          provider => $provider,
           before   => Service['webhook'],
         }
       }

--- a/spec/classes/install/puppet_gem_spec.rb
+++ b/spec/classes/install/puppet_gem_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+describe 'r10k::install::puppet_gem' , :type => 'class' do
+  context "on a RedHat 6 OS installing 1.5.1 via puppet_gem for Puppet FOSS 4.x" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :puppetversion          => '4.2.1',
+        :operatingsystemrelease => '6',
+        :is_pe                  => 'false'
+      }
+    end
+    it { should contain_file("/usr/bin/r10k").with(
+        'ensure'  => 'link',
+        'target'  => '/opt/puppetlabs/bin/r10k',
+        'require' => 'Package[r10k]'
+      )
+    }
+  end
+end

--- a/spec/classes/install/puppet_gem_spec.rb
+++ b/spec/classes/install/puppet_gem_spec.rb
@@ -11,7 +11,7 @@ describe 'r10k::install::puppet_gem' , :type => 'class' do
     end
     it { should contain_file("/usr/bin/r10k").with(
         'ensure'  => 'link',
-        'target'  => '/opt/puppetlabs/bin/r10k',
+        'target'  => '/opt/puppetlabs/puppet/bin/r10k',
         'require' => 'Package[r10k]'
       )
     }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -92,6 +92,31 @@ describe 'r10k::install' , :type => 'class' do
       )
     }
   end
+  context "on a RedHat 6 OS installing 1.5.1 with puppet_gem provider" do
+    let :params do
+      {
+        :package_name           => 'r10k',
+        :version                => '1.5.1',
+        :provider               => 'puppet_gem',
+        :keywords               => '',
+        :manage_ruby_dependency => 'declare',
+        :install_options        => '',
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+      }
+    end
+    it { should contain_class("git") }
+    it { should contain_class("r10k::install::puppet_gem") }
+    it { should contain_package("r10k").with(
+      'ensure'   => '1.5.1',
+      'provider' => 'puppet_gem'
+      )
+    }
+  end
   context "on a RedHat 5 OS installing 1.1.0 with bundle provider" do
     let :params do
       {
@@ -225,6 +250,40 @@ describe 'r10k::install' , :type => 'class' do
     }
 
   end
+  context "Puppet FOSS 4.2.x on a RedHat 6 installing via puppet_gem" do
+    let :params do
+      {
+        :manage_ruby_dependency => 'declare',
+        :install_options        => '',
+        :package_name           => 'r10k',
+        :provider               => 'puppet_gem',
+        :version                => '1.5.1',
+        :keywords               => '',
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => false,
+        :puppetversion          => '4.2.1'
+      }
+    end
+    it { should_not contain_package("r10k").with(
+        :ensure     => '1.5.1',
+        :provider   => 'puppet_gem'
+      )
+    }
+
+   it { should_not contain_file("/usr/bin/r10k").with(
+        'ensure'  => 'link',
+        'target'  => '/opt/puppetlabs/bin/r10k',
+        'require' => 'Package[r10k]'
+      )
+    }
+
+  end
   context "Puppet Enterprise 3.7.x on a RedHat 5 installing via pe_gem" do
     let :params do
       {
@@ -281,6 +340,34 @@ describe 'r10k::install' , :type => 'class' do
     it { should contain_package("r10k").with(
         :ensure     => '1.5.0',
         :provider   => 'pe_gem',
+        :install_options => ['--no-ri', '--no-rdoc']
+      )
+    }
+  end
+  context "Puppet FOSS 4.2.x on a RedHat 6 installing via puppet_gem with empty install_options" do
+    let :params do
+      {
+        :manage_ruby_dependency => 'BOGON',
+        :package_name           => 'r10k',
+        :provider               => 'puppet_gem',
+        :version                => '1.5.1',
+        :keywords               => '',
+        :install_options        => [],
+      }
+    end
+    let :facts do
+      {
+        :manage_ruby_dependency => 'BOGON',
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => '',
+        :puppet_version             => '4.2.1'
+      }
+    end
+    it { should contain_package("r10k").with(
+        :ensure     => '1.5.1',
+        :provider   => 'puppet_gem',
         :install_options => ['--no-ri', '--no-rdoc']
       )
     }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -278,7 +278,7 @@ describe 'r10k::install' , :type => 'class' do
 
    it { should_not contain_file("/usr/bin/r10k").with(
         'ensure'  => 'link',
-        'target'  => '/opt/puppetlabs/bin/r10k',
+        'target'  => '/opt/puppetlabs/puppet/bin/r10k',
         'require' => 'Package[r10k]'
       )
     }

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -30,6 +30,22 @@ describe 'r10k::webhook' , :type => 'class' do
       )
     }
   end
+  context 'Puppet FOSS 4.2.x on a RedHat 6 installing webhook' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'false',
+        :puppetversion          => '4.2.1'
+      }
+    end
+    it { should contain_package('sinatra').with(
+        'ensure'   => 'installed',
+        'provider' => 'puppet_gem'
+      )
+    }
+  end
   context 'Puppet 2.7.0 FOSS on a RedHat 5 installing webhook' do
     let :facts do
       {

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,4 +1,4 @@
-#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/bin' end %>/ruby
+#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif @puppetversion >= '4.2.0' then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster
 # Authors:


### PR DESCRIPTION
Add support for puppet_gem provider to account for included ruby/gem in Puppet FOSS 4.2.0 and higher.

This is not well tested, but is working in my environment with Puppet FOSS 4.2.0.  It was done in a bit of a rush and I tried to model what was being done for the other provider methods without breaking anything.

Please take a look and suggest improvements.  Relates to issue #220 that I submitted.

