### PR TITLE
Add a custom fact 'r10k_path'

### DIFF
--- a/lib/facter/r10k_path.rb
+++ b/lib/facter/r10k_path.rb
@@ -1,0 +1,11 @@
+Facter.add(:r10k_path) do
+  confine :kernel => :linux
+  setcode do
+    path = Facter::Util::Resolution.exec("which r10k")
+    if path
+      path.to_s
+    else
+      nil
+    end
+  end
+end

--- a/spec/unit/facter/r10k_path_spec.rb
+++ b/spec/unit/facter/r10k_path_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe "Facter::Util::Fact" do
+  before {
+    Facter.clear
+    allow(Facter.fact(:kernel)).to receive(:value).and_return("Linux")
+  }
+
+  describe "r10k_path" do
+    it do
+      allow(Facter::Util::Resolution).to receive(:exec).with("which r10k").
+      and_return("/usr/local/bin/r10k")
+      Facter.fact(:r10k_path).value.should == "/usr/local/bin/r10k"
+    end
+  end
+end


### PR DESCRIPTION
Solves #210.

This will send a fact with the absolute path to the installed r10k binary to the master.

There is just one regression without an easy solution: the installed binary needs to be in the path of the user puppet agent is run as, which may be very different than the path the webhook / mco user uses.