### PR TITLE
OpenBSD 5.8 switches default ruby version to 2.2, therefore

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,7 +23,13 @@ class r10k::install (
 
   if $package_name == '' {
     case $provider {
-      'openbsd': { $real_package_name = 'ruby21-r10k' }
+      'openbsd': {
+                    if (versioncmp($::kernelversion, '5.8') < 0) {
+                      $real_package_name = 'ruby21-r10k'
+                    } else {
+                      $real_package_name = 'ruby22-r10k'
+                    }
+                  }
       'portage': { $real_package_name = 'app-admin/r10k' }
       'yum':     { $real_package_name = 'rubygem-r10k' }
       default:   { $real_package_name = 'r10k' }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -150,7 +150,11 @@ class r10k::params
       'openbsd': {
         $plugins_dir     = '/usr/local/libexec/mcollective/mcollective'
         $provider        = 'openbsd'
-        $r10k_binary     = 'r10k21'
+        if (versioncmp($::kernelversion, '5.8') < 0) {
+          $r10k_binary     = 'r10k21'
+        } else {
+          $r10k_binary     = 'r10k22'
+        }
         $mc_service_name = 'mcollectived'
       }
       default: {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -410,7 +410,7 @@ describe 'r10k::install' , :type => 'class' do
       )
     }
   end
-  context "On OpenBSD installing via packages" do
+  context "On OpenBSD 5.7 installing via packages" do
     let :params do
       {
         :install_options        => '',
@@ -425,10 +425,32 @@ describe 'r10k::install' , :type => 'class' do
     let :facts do
       {
         :osfamily               => 'OpenBSD',
+        :kernelversion          => '5.7',
       }
     end
     it { should_not contain_class("git") }
     it { should contain_package("ruby21-r10k")}
+  end
+  context "On OpenBSD 5.8 installing via packages" do
+    let :params do
+      {
+        :install_options        => '',
+        :keywords               => '',
+        :manage_ruby_dependency => 'declare',
+        :package_name           => 'ruby22-r10k',
+        :provider               => 'openbsd',
+        :version                => 'latest',
+        :puppet_master          => true,
+      }
+    end
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :kernelversion          => '5.8',
+      }
+    end
+    it { should_not contain_class("git") }
+    it { should contain_package("ruby22-r10k")}
   end
   context "on a RedHat 6 OS installing 1.5.1 with puppet_gem provider" do
     let :params do

--- a/spec/classes/postrun_command_spec.rb
+++ b/spec/classes/postrun_command_spec.rb
@@ -44,11 +44,23 @@ describe 'r10k::postrun_command' , :type => 'class' do
       }
     end
   end
-  context 'Puppet FOSS on a OpenBSD install' do
+  context 'Puppet FOSS on a OpenBSD 5.7 install' do
     let :facts do
       {
         :osfamily               => 'OpenBSD',
+        :kernelversion          => '5.7',
         :is_pe                  => 'false'
+      }
+    end
+    context "adding default postrun_command" do
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k21 deploy environment -p',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
       }
     end
     context "adding custom postrun_command" do
@@ -81,6 +93,60 @@ describe 'r10k::postrun_command' , :type => 'class' do
         'section' => 'agent',
         'setting' => 'postrun_command',
         'value'   => 'r10k21 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+  end
+  context 'Puppet FOSS on a OpenBSD 5.8 install' do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :kernelversion          => '5.8',
+        :is_pe                  => 'false'
+      }
+    end
+    context "adding default postrun_command" do
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k22 deploy environment -p',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+    context "adding custom postrun_command" do
+      let :params do
+        {
+          :command               => 'r10k22 synchronize',
+          :ensure                => 'present',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k22 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+    context "removing custom postrun_command" do
+      let :params do
+        {
+          :command               => 'r10k22 synchronize',
+          :ensure                => 'absent',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_postrun_command").with(
+        'ensure'  => 'absent',
+        'section' => 'agent',
+        'setting' => 'postrun_command',
+        'value'   => 'r10k22 synchronize',
         'path'    => '/etc/puppet/puppet.conf'
       )
       }

--- a/spec/classes/prerun_command_spec.rb
+++ b/spec/classes/prerun_command_spec.rb
@@ -44,11 +44,23 @@ describe 'r10k::prerun_command' , :type => 'class' do
       }
     end
   end
-  context 'Puppet FOSS on OpenBSD' do
+  context 'Puppet FOSS on OpenBSD 5.7' do
     let :facts do
       {
         :osfamily               => 'OpenBSD',
+        :kernelversion          => '5.7',
         :is_pe                  => 'false'
+      }
+    end
+    context "default prerun_command" do
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k21 deploy environment -p',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
       }
     end
     context "adding custom prerun_command" do
@@ -81,6 +93,60 @@ describe 'r10k::prerun_command' , :type => 'class' do
         'section' => 'agent',
         'setting' => 'prerun_command',
         'value'   => 'r10k21 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+  end
+  context 'Puppet FOSS on OpenBSD 5.8' do
+    let :facts do
+      {
+        :osfamily               => 'OpenBSD',
+        :kernelversion          => '5.8',
+        :is_pe                  => 'false'
+      }
+    end
+    context "default prerun_command" do
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k22 deploy environment -p',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+    context "adding custom prerun_command" do
+      let :params do
+        {
+          :command               => 'r10k22 synchronize',
+          :ensure                => 'present',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'present',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k22 synchronize',
+        'path'    => '/etc/puppet/puppet.conf'
+      )
+      }
+    end
+    context "removing custom prerun_command" do
+      let :params do
+        {
+          :command               => 'r10k22 synchronize',
+          :ensure                => 'absent',
+        }
+      end
+      it { should contain_class("r10k::params") }
+      it { should contain_ini_setting("r10k_prerun_command").with(
+        'ensure'  => 'absent',
+        'section' => 'agent',
+        'setting' => 'prerun_command',
+        'value'   => 'r10k22 synchronize',
         'path'    => '/etc/puppet/puppet.conf'
       )
       }


### PR DESCRIPTION
the name of the r10k binary and package name changed. Use versioncmp()
with the ::kernelversion to determine the right names where appropriate.
I don't use ::operatingsystemrelease, since that contains prefixes
like -stable, -snapshot, -beta etc, which confuses versioncmp().
::kernelversion is more stable in that regard.

Tested on a 5.7-snapshot, and 5.8-beta, on the 5.8 using puppet-3.8.1, r10k-2.0.2, ruby-2.2.2.

Note that I was the one who opened the PR to support OpenBSD at all, that was at 5.7 times.
The versioncmp should also be correct for OpenBSD 5.6, unsure about 5.5. But since it's still
as it is, I think it's fine to not care too much about such old versions ;)

Let me know if there is anything to update/enhance/etc. and I'm happy to do so.