### PR TITLE
Making r10k webhook 2015.x compatible

### DIFF
--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -17,19 +17,19 @@ describe 'r10k::webhook::package' , :type => 'class' do
     end
     it { should contain_package('sinatra').with(
         'ensure'   => 'installed',
-        'provider' => 'puppet_gem',
+        'provider' => 'puppet_gem'
       )
     }
     it { should contain_package('rack').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
     it { should_not contain_package('webrick').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
     it { should_not contain_package('json').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
   end
@@ -54,15 +54,15 @@ describe 'r10k::webhook::package' , :type => 'class' do
       )
     }
     it { should contain_package('rack').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
     it { should_not contain_package('webrick').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
     it { should_not contain_package('json').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
   end
@@ -82,19 +82,19 @@ describe 'r10k::webhook::package' , :type => 'class' do
     end
     it { should contain_package('sinatra').with(
         'ensure'   => 'installed',
-        'provider' => 'pe_gem',
+        'provider' => 'pe_gem'
       )
     }
     it { should_not contain_package('rack').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
     it { should_not contain_package('webrick').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
     it { should_not contain_package('json').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
   end
@@ -110,26 +110,26 @@ describe 'r10k::webhook::package' , :type => 'class' do
     end
     it { should_not contain_package('webrick').with(
         'ensure'   => 'installed',
-        'provider' => 'puppet_gem',
+        'provider' => 'puppet_gem'
       )
     }
     it { should_not contain_package('json').with(
         'ensure'   => 'installed',
-        'provider' => 'puppet_gem',
+        'provider' => 'puppet_gem'
       )
     }
     it { should contain_package('sinatra').with(
         'ensure'   => 'installed',
         'provider' => 'puppet_gem',
-        'before' => 'Service[webhook]',
+        'before' => 'Service[webhook]'
       )
     }
     it { should contain_package('rack').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
     it { should_not contain_package('webrick').with(
-        'ensure' => 'installed',
+        'ensure' => 'installed'
       )
     }
   end
@@ -144,22 +144,22 @@ describe 'r10k::webhook::package' , :type => 'class' do
     end
     it { should contain_package('sinatra').with(
         'ensure'   => 'installed',
-        'provider' => 'gem',
+        'provider' => 'gem'
       )
     }
     it { should contain_package('webrick').with(
         'ensure'   => 'installed',
-        'provider' => 'gem',
+        'provider' => 'gem'
       )
     }
     it { should contain_package('json').with(
         'ensure'   => 'installed',
-        'provider' => 'gem',
+        'provider' => 'gem'
       )
     }
     it { should_not contain_package('rack').with(
         'ensure'   => 'installed',
-        'provider' => 'gem',
+        'provider' => 'gem'
       )
     }
   end

--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -1,0 +1,166 @@
+require 'spec_helper'
+describe 'r10k::webhook::package' , :type => 'class' do
+  context 'Puppet Enterprise 2015.x on a RedHat 5 installing webhook' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true',
+        :puppetversion          => '4.2.0'
+      }
+    end
+    let :params do
+      {
+        :is_pe_server => true,
+      }
+    end
+    it { should contain_package('sinatra').with(
+        'ensure'   => 'installed',
+        'provider' => 'puppet_gem',
+      )
+    }
+    it { should contain_package('rack').with(
+        'ensure' => 'installed',
+      )
+    }
+    it { should_not contain_package('webrick').with(
+        'ensure' => 'installed',
+      )
+    }
+    it { should_not contain_package('json').with(
+        'ensure' => 'installed',
+      )
+    }
+  end
+  context 'Puppet Enterprise 3.7.0 on a RedHat 5 installing webhook' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true',
+        :puppetversion          => '3.7.0'
+      }
+    end
+    let :params do
+      {
+        :is_pe_server => true,
+      }
+    end
+    it { should contain_package('sinatra').with(
+        'ensure'   => 'installed',
+        'provider' => 'pe_gem',
+      )
+    }
+    it { should contain_package('rack').with(
+        'ensure' => 'installed',
+      )
+    }
+    it { should_not contain_package('webrick').with(
+        'ensure' => 'installed',
+      )
+    }
+    it { should_not contain_package('json').with(
+        'ensure' => 'installed',
+      )
+    }
+  end
+  context 'Puppet Enterprise 3.6.0 on a RedHat 5 installing webhook' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :puppetversion          => '3.6.0'
+      }
+    end
+    let :params do
+      {
+        :is_pe_server => true,
+      }
+    end
+    it { should contain_package('sinatra').with(
+        'ensure'   => 'installed',
+        'provider' => 'pe_gem',
+      )
+    }
+    it { should_not contain_package('rack').with(
+        'ensure' => 'installed',
+      )
+    }
+    it { should_not contain_package('webrick').with(
+        'ensure' => 'installed',
+      )
+    }
+    it { should_not contain_package('json').with(
+        'ensure' => 'installed',
+      )
+    }
+  end
+  context 'Puppet FOSS 2015.x on a RedHat 5 installing webhook' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true',
+        :puppetversion          => '4.2.0'
+      }
+    end
+    it { should_not contain_package('webrick').with(
+        'ensure'   => 'installed',
+        'provider' => 'puppet_gem',
+      )
+    }
+    it { should_not contain_package('json').with(
+        'ensure'   => 'installed',
+        'provider' => 'puppet_gem',
+      )
+    }
+    it { should contain_package('sinatra').with(
+        'ensure'   => 'installed',
+        'provider' => 'puppet_gem',
+        'before' => 'Service[webhook]',
+      )
+    }
+    it { should contain_package('rack').with(
+        'ensure' => 'installed',
+      )
+    }
+    it { should_not contain_package('webrick').with(
+        'ensure' => 'installed',
+      )
+    }
+  end
+  context 'Puppet FOSS 3.6.0 on a RedHat 5 installing webhook' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :puppetversion          => '3.6.0'
+      }
+    end
+    it { should contain_package('sinatra').with(
+        'ensure'   => 'installed',
+        'provider' => 'gem',
+      )
+    }
+    it { should contain_package('webrick').with(
+        'ensure'   => 'installed',
+        'provider' => 'gem',
+      )
+    }
+    it { should contain_package('json').with(
+        'ensure'   => 'installed',
+        'provider' => 'gem',
+      )
+    }
+    it { should_not contain_package('rack').with(
+        'ensure'   => 'installed',
+        'provider' => 'gem',
+      )
+    }
+  end
+end

--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -50,7 +50,7 @@ describe 'r10k::webhook::package' , :type => 'class' do
     end
     it { should contain_package('sinatra').with(
         'ensure'   => 'installed',
-        'provider' => 'pe_gem',
+        'provider' => 'pe_gem'
       )
     }
     it { should contain_package('rack').with(


### PR DESCRIPTION
Testing that the correct packages are in the catalog when installing r10k webhook.  Satisfying the following scenarios:
 
* PE >=2015.x with webhook
* PE Puppet <v4.2.0, >=v3.7.0 with webhook
* PE Puppet <v3.7.0 with webhook
* FOSS >=2015.x with webhook
* FOSS Puppet <v4.2.0, >=v3.7.0 with webhook
* FOSS Puppet <v3.7.0 with webhook
