### PR TITLE
Let rb scripts resolve what ruby to use themselves

### DIFF
--- a/files/prefix_command.rb
+++ b/files/prefix_command.rb
@@ -1,4 +1,4 @@
-#!/opt/puppet/bin/ruby
+#!/usr/bin/env ruby
 require 'json'
 require 'yaml'
 


### PR DESCRIPTION
when creating rpm packages for this module, the resulting rpm complains that our systems dont have the required /opt/puppet/bin/ruby.
Its nicer to let the file/system decide what ruby to use