### PR TITLE
Add the ability to respond only to certain events

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,7 +46,8 @@ class r10k::params
   $webhook_r10k_deploy_arguments = '-pv'
   $webhook_bin_template          = 'r10k/webhook.bin.erb'
   $webhook_yaml_template         = 'r10k/webhook.yaml.erb'
-  $webhook_r10k_command_prefix        = 'umask 0022;' # 'sudo' is the canonical example for this
+  $webhook_r10k_command_prefix   = 'umask 0022;' # 'sudo' is the canonical example for this
+  $webhook_repository_events     = undef
 
   if $::osfamily == 'Debian' {
     $functions_path     = '/lib/lsb/init-functions'

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -28,6 +28,7 @@ class r10k::webhook::config (
   $private_key_path      = $r10k::params::webhook_private_key_path,
   $yaml_template         = $r10k::params::webhook_yaml_template,
   $command_prefix        = $r10k::params::webhook_r10k_command_prefix,
+  $repository_events     = $r10k::params::webhook_repository_events,
   $configfile            = '/etc/webhook.yaml',
   $manage_symlink        = false,
   $configfile_symlink    = '/etc/webhook.yaml',
@@ -56,6 +57,7 @@ class r10k::webhook::config (
       'public_key_path'       => $public_key_path,
       'private_key_path'      => $private_key_path,
       'command_prefix'        => $command_prefix,
+      'repository_events'     => $repository_events,
     }
   } else {
     validate_hash($hash)

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -21,26 +21,26 @@ describe 'r10k::webhook::config' , :type => 'class' do
     }
 
     content = """---
-  access_logfile: \"/var/log/webhook/access.log\"
-  bind_address: \"0.0.0.0\"
-  certname: \"peadmin\"
-  certpath: \"/var/lib/peadmin/.mcollective.d\"
-  client_cfg: \"/var/lib/peadmin/.mcollective\"
-  client_timeout: \"120\"
-  command_prefix: \"umask 0022;\"
-  discovery_timeout: \"10\"
-  enable_ssl: true
-  pass: \"peadmin\"
-  port: \"8088\"
-  prefix: false
-  prefix_command: \"/bin/echo example\"
-  private_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-private.pem\"
-  protected: true
-  public_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-cert.pem\"
-  r10k_deploy_arguments: \"-pv\"
-  use_mco_ruby: false
-  use_mcollective: true
-  user: \"peadmin\"
+access_logfile: \"/var/log/webhook/access.log\"
+bind_address: \"0.0.0.0\"
+certname: \"peadmin\"
+certpath: \"/var/lib/peadmin/.mcollective.d\"
+client_cfg: \"/var/lib/peadmin/.mcollective\"
+client_timeout: \"120\"
+command_prefix: \"umask 0022;\"
+discovery_timeout: \"10\"
+enable_ssl: true
+pass: \"peadmin\"
+port: \"8088\"
+prefix: false
+prefix_command: \"/bin/echo example\"
+private_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-private.pem\"
+protected: true
+public_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-cert.pem\"
+r10k_deploy_arguments: \"-pv\"
+use_mco_ruby: false
+use_mcollective: true
+user: \"peadmin\"
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
@@ -64,23 +64,75 @@ describe 'r10k::webhook::config' , :type => 'class' do
     }
 
     content = """---
-  access_logfile: \"/var/log/webhook/access.log\"
-  bind_address: \"0.0.0.0\"
-  client_cfg: \"/var/lib/peadmin/.mcollective\"
-  client_timeout: \"120\"
-  command_prefix: \"umask 0022;\"
-  discovery_timeout: \"10\"
-  enable_ssl: true
-  pass: \"puppet\"
-  port: \"8088\"
-  prefix: false
-  prefix_command: \"/bin/echo example\"
-  protected: true
-  r10k_deploy_arguments: \"-pv\"
-  use_mco_ruby: false
-  use_mcollective: true
-  user: \"puppet\"
+access_logfile: \"/var/log/webhook/access.log\"
+bind_address: \"0.0.0.0\"
+client_cfg: \"/var/lib/peadmin/.mcollective\"
+client_timeout: \"120\"
+command_prefix: \"umask 0022;\"
+discovery_timeout: \"10\"
+enable_ssl: true
+pass: \"puppet\"
+port: \"8088\"
+prefix: false
+prefix_command: \"/bin/echo example\"
+protected: true
+r10k_deploy_arguments: \"-pv\"
+use_mco_ruby: false
+use_mcollective: true
+user: \"puppet\"
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
+
+  context 'Puppet Enterprise 3.7.0 on a RedHat 5 installing webhook with events defined' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :operatingsystem        => 'Centos',
+        :is_pe                  => 'true',
+        :pe_version             => '3.7.0'
+      }
+    end
+    let(:params) do
+      {
+        :repository_events => ['merge','release'],
+      }
+    end
+    it { should contain_file('webhook.yaml').with(
+        'path'   => '/etc/webhook.yaml',
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => '0',
+        'mode'   => '0644',
+        'notify' => 'Service[webhook]'
+      )
+    }
+
+    content = """---
+access_logfile: \"/var/log/webhook/access.log\"
+bind_address: \"0.0.0.0\"
+certname: \"peadmin\"
+certpath: \"/var/lib/peadmin/.mcollective.d\"
+client_cfg: \"/var/lib/peadmin/.mcollective\"
+client_timeout: \"120\"
+command_prefix: \"umask 0022;\"
+discovery_timeout: \"10\"
+enable_ssl: true
+pass: \"peadmin\"
+port: \"8088\"
+prefix: false
+prefix_command: \"/bin/echo example\"
+private_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-private.pem\"
+protected: true
+public_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-cert.pem\"
+r10k_deploy_arguments: \"-pv\"
+repository_events: [\"merge\",\"release\"]
+use_mco_ruby: false
+use_mcollective: true
+user: \"peadmin\"
+"""
+    it { should contain_file('webhook.yaml').with_content(content) }
+  end
+
 end

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -127,7 +127,7 @@ private_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-private.pem\"
 protected: true
 public_key_path: \"/var/lib/peadmin/.mcollective.d/peadmin-cert.pem\"
 r10k_deploy_arguments: \"-pv\"
-repository_events: [\"merge\",\"release\"]
+repository_events: [\"merge\", \"release\"]
 use_mco_ruby: false
 use_mcollective: true
 user: \"peadmin\"

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -77,9 +77,12 @@ class Server < Sinatra::Base
     protected! if $config['protected']
     $logger.info("authenticated: #{$config['user']}")
     request.body.rewind  # in case someone already read it
-    decoded = request.body.read
 
-    data = JSON.parse(decoded, :quirks_mode => true)
+    # Short circuit if we're ignoring this event
+    return 200 if ignore_event?
+
+    decoded = request.body.read
+    data    = JSON.parse(decoded, :quirks_mode => true)
 
     if data['repository'].has_key?('full_name')
       # handle BitBucket webhook...
@@ -109,8 +112,8 @@ class Server < Sinatra::Base
     $logger.info("authenticated: #{$config['user']}")
     request.body.rewind  # in case someone already read it
 
-    # Return success without deploying if this is a GitHub ping event
-    return 200 if request.env['HTTP_X_GITHUB_EVENT'] == 'ping'
+    # Short circuit if we're ignoring this event
+    return 200 if ignore_event?
 
     # Check if content type is x-www-form-urlencoded
     if request.content_type.to_s.downcase.eql?('application/x-www-form-urlencoded')
@@ -141,6 +144,18 @@ class Server < Sinatra::Base
   end
 
   helpers do
+
+    # Check to see if this is an event we care about. Default to responding to all events
+    def ignore_event?
+      # Explicitly ignore GitHub ping events
+      return true if request.env['HTTP_X_GITHUB_EVENT'] == 'ping'
+
+      list  = $config['repository_events']
+      event = request.env['HTTP_X_GITHUB_EVENT']
+
+      # negate this, because we should respond if any of these conditions are true
+      ! (list.nil? or list == event or list.include?(event))
+    end
 
     def deploy_module(module_name)
       begin

--- a/templates/webhook.yaml.erb
+++ b/templates/webhook.yaml.erb
@@ -1,6 +1,16 @@
 ---
 <% @webhook_hash.sort.each do |key,value| -%>
-<% if value != :undef -%>
-  <%=key-%>: <%= (value.class == TrueClass  || value.class == FalseClass ) ? value : "\"#{value}\"" %>
+<% if value != :undef and ! value.nil? -%>
+<%
+  value = case value
+  when TrueClass, FalseClass
+    value
+  when Array
+    value.sort.to_s
+  else
+    "\"#{value}\""
+  end
+-%>
+<%=key-%>: <%= value %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This adds a new webhook param, which allows you to define an event or
list of events to respond to as a single string or an array.

``` Puppet
class {'r10k::webhook::config':
  enable_ssl        => true,
  protected         => true,
  repository_events => ['push','release'],
  notify            => Service['webhook'],
}
```

This required extending the `webhook.yaml.erb` to also expand and sort
array data types.

Yes, you could do the same by only configuring certain github events,
but this allows you to more easily do it in code on the master.

Limitations: currently supports only github events.