### PR TITLE
Automatically calculate some prefixes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class r10k::params
   $webhook_protected             = true
   $webhook_discovery_timeout     = 10
   $webhook_client_timeout        = 120
-  $webhook_prefix                = false         # :repo | :user | :command (or true for backwards compatibility) | 'string' | false
+  $webhook_prefix                = false         # ':repo' | ':user' | ':command' (or true for backwards compatibility) | 'string' | false
   $webhook_prefix_command        = '/bin/echo example'
   $webhook_enable_ssl            = true
   $webhook_use_mcollective       = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class r10k::params
   $webhook_protected             = true
   $webhook_discovery_timeout     = 10
   $webhook_client_timeout        = 120
-  $webhook_prefix                = false
+  $webhook_prefix                = false         # :repo | :user | :command (or true for backwards compatibility) | 'string' | false
   $webhook_prefix_command        = '/bin/echo example'
   $webhook_enable_ssl            = true
   $webhook_use_mcollective       = true

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -126,17 +126,24 @@ class Server < Sinatra::Base
     # github sends a 'ref', stash sends an array in 'refChanges'
     branch = ( data['ref'] || data['refChanges'][0]['refId'] rescue nil || data['push']['changes'][0]['new']['name'] ).sub('refs/heads/', '')
 
-    # If prefix is enabled in our config file run the command to determine the prefix
-    if $config['prefix']
-      prefix = run_prefix_command(data.to_json)
-      if prefix.empty?
-        deploy(branch)
-      else
-        deploy("#{prefix}_#{branch}")
-      end
-    else
-      deploy(branch)
+    # If prefix is enabled in our config file, determine what the prefix should be
+    prefix = case $config['prefix']
+    when :repo
+      repo_name(data)
+    when :user
+      repo_user(data)
+    when :command, TrueClass
+      run_prefix_command(data.to_json)
+    when String
+      $config['prefix']
     end
+
+    if prefix.nil? or prefix.empty?
+      deploy(branch)
+    else
+      deploy("#{prefix}_#{branch}")
+    end
+
   end
 
   not_found do
@@ -238,6 +245,16 @@ class Server < Sinatra::Base
       @auth.provided? && @auth.basic? && @auth.credentials &&
       @auth.credentials == [$config['user'],$config['pass']]
     end  #end authorized?
+
+    def repo_name(data)
+      # Tested with GitHub only
+      data['repository']['name'] rescue nil
+    end
+
+    def repo_user(data)
+      # Tested with GitHub only
+      data['repository']['owner']['name'] rescue nil
+    end
 
     def run_prefix_command(payload)
       IO.popen($config['prefix_command'], mode='r+') do |io|

--- a/templates/webhook.yaml.erb
+++ b/templates/webhook.yaml.erb
@@ -3,10 +3,12 @@
 <% if value != :undef and ! value.nil? -%>
 <%
   value = case value
-  when TrueClass, FalseClass, Symbol
+  when TrueClass, FalseClass
     value
   when Array
     value.sort.inspect.to_s
+  when /^:/
+    value.to_sym
   else
     "\"#{value}\""
   end

--- a/templates/webhook.yaml.erb
+++ b/templates/webhook.yaml.erb
@@ -3,7 +3,7 @@
 <% if value != :undef and ! value.nil? -%>
 <%
   value = case value
-  when TrueClass, FalseClass
+  when TrueClass, FalseClass, Symbol
     value
   when Array
     value.sort.inspect.to_s


### PR DESCRIPTION
Allows one to set the webhook's `prefix` to:

* `:repo`: the repository name
* `:user`: the owner of the repository
* `:command`: run a command using the posted data to determine prefix
    * This is existing behaviour
    * Uses `prefix command`
    * Aliased to `true` for backwards compatibility
* A string: pass the prefix as a static string
* `false`: disable the prefix

This is currently tested only on GitHub.