### PR TITLE
Add single request concurrency option in r10k webhook

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,6 +48,7 @@ class r10k::params
   $webhook_yaml_template         = 'r10k/webhook.yaml.erb'
   $webhook_r10k_command_prefix   = 'umask 0022;' # 'sudo' is the canonical example for this
   $webhook_repository_events     = undef
+  $webhook_enable_mutex_lock     = false
 
   if $::osfamily == 'Debian' {
     $functions_path     = '/lib/lsb/init-functions'

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -32,6 +32,7 @@ class r10k::webhook::config (
   $configfile            = '/etc/webhook.yaml',
   $manage_symlink        = false,
   $configfile_symlink    = '/etc/webhook.yaml',
+  $enable_mutex_lock     = $r10k::params::webhook_enable_mutex_lock,
 ) inherits r10k::params {
 
   if $hash == 'UNSET' {
@@ -58,6 +59,7 @@ class r10k::webhook::config (
       'private_key_path'      => $private_key_path,
       'command_prefix'        => $command_prefix,
       'repository_events'     => $repository_events,
+      'enable_mutex_lock'     => $enable_mutex_lock,
     }
   } else {
     validate_hash($hash)

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -41,6 +41,7 @@ r10k_deploy_arguments: \"-pv\"
 use_mco_ruby: false
 use_mcollective: true
 user: \"peadmin\"
+enable_mutex_lock: false
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
@@ -80,6 +81,100 @@ r10k_deploy_arguments: \"-pv\"
 use_mco_ruby: false
 use_mcollective: true
 user: \"puppet\"
+enable_mutex_lock: false
+"""
+    it { should contain_file('webhook.yaml').with_content(content) }
+  end
+
+    context 'FOSS 4.0 on a RedHat 6 installing webhook with mutex lock enabled' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :operatingsystem        => 'Centos',
+        :pe_version             => '4.2.0'
+      }
+    end
+    let(:params) do
+      {
+        :enable_mutex_lock => true,
+      }
+    end
+    it { should contain_file('webhook.yaml').with(
+        'path'   => '/etc/webhook.yaml',
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => '0',
+        'mode'   => '0644',
+        'notify' => 'Service[webhook]'
+      )
+    }
+
+    content = """---
+access_logfile: \"/var/log/webhook/access.log\"
+bind_address: \"0.0.0.0\"
+client_cfg: \"/var/lib/peadmin/.mcollective\"
+client_timeout: \"120\"
+command_prefix: \"umask 0022;\"
+discovery_timeout: \"10\"
+enable_ssl: true
+pass: \"puppet\"
+port: \"8088\"
+prefix: false
+prefix_command: \"/bin/echo example\"
+protected: true
+r10k_deploy_arguments: \"-pv\"
+use_mco_ruby: false
+use_mcollective: true
+user: \"puppet\"
+enable_mutex_lock: true
+"""
+    it { should contain_file('webhook.yaml').with_content(content) }
+  end
+
+
+    context 'FOSS 4.0 on a RedHat 7 installing webhook with mutex lock enabled' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '7',
+        :operatingsystem        => 'Centos',
+        :pe_version             => '4.2.0'
+      }
+    end
+    let(:params) do
+      {
+        :enable_mutex_lock => true,
+      }
+    end
+    it { should contain_file('webhook.yaml').with(
+        'path'   => '/etc/webhook.yaml',
+        'ensure' => 'file',
+        'owner'  => 'root',
+        'group'  => '0',
+        'mode'   => '0644',
+        'notify' => 'Service[webhook]'
+      )
+    }
+
+    content = """---
+access_logfile: \"/var/log/webhook/access.log\"
+bind_address: \"0.0.0.0\"
+client_cfg: \"/var/lib/peadmin/.mcollective\"
+client_timeout: \"120\"
+command_prefix: \"umask 0022;\"
+discovery_timeout: \"10\"
+enable_ssl: true
+pass: \"puppet\"
+port: \"8088\"
+prefix: false
+prefix_command: \"/bin/echo example\"
+protected: true
+r10k_deploy_arguments: \"-pv\"
+use_mco_ruby: false
+use_mcollective: true
+user: \"puppet\"
+enable_mutex_lock: true
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
@@ -131,6 +226,7 @@ repository_events: [\"merge\", \"release\"]
 use_mco_ruby: false
 use_mcollective: true
 user: \"peadmin\"
+enable_mutex_lock: false
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -29,6 +29,7 @@ client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
 command_prefix: \"umask 0022;\"
 discovery_timeout: \"10\"
+enable_mutex_lock: false
 enable_ssl: true
 pass: \"peadmin\"
 port: \"8088\"
@@ -41,7 +42,6 @@ r10k_deploy_arguments: \"-pv\"
 use_mco_ruby: false
 use_mcollective: true
 user: \"peadmin\"
-enable_mutex_lock: false
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
@@ -71,6 +71,7 @@ client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
 command_prefix: \"umask 0022;\"
 discovery_timeout: \"10\"
+enable_mutex_lock: false
 enable_ssl: true
 pass: \"puppet\"
 port: \"8088\"
@@ -81,7 +82,6 @@ r10k_deploy_arguments: \"-pv\"
 use_mco_ruby: false
 use_mcollective: true
 user: \"puppet\"
-enable_mutex_lock: false
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
@@ -117,6 +117,7 @@ client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
 command_prefix: \"umask 0022;\"
 discovery_timeout: \"10\"
+enable_mutex_lock: true
 enable_ssl: true
 pass: \"puppet\"
 port: \"8088\"
@@ -127,7 +128,6 @@ r10k_deploy_arguments: \"-pv\"
 use_mco_ruby: false
 use_mcollective: true
 user: \"puppet\"
-enable_mutex_lock: true
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
@@ -164,6 +164,7 @@ client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
 command_prefix: \"umask 0022;\"
 discovery_timeout: \"10\"
+enable_mutex_lock: true
 enable_ssl: true
 pass: \"puppet\"
 port: \"8088\"
@@ -174,7 +175,6 @@ r10k_deploy_arguments: \"-pv\"
 use_mco_ruby: false
 use_mcollective: true
 user: \"puppet\"
-enable_mutex_lock: true
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end
@@ -213,6 +213,7 @@ client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
 command_prefix: \"umask 0022;\"
 discovery_timeout: \"10\"
+enable_mutex_lock: false
 enable_ssl: true
 pass: \"peadmin\"
 port: \"8088\"
@@ -226,7 +227,6 @@ repository_events: [\"merge\", \"release\"]
 use_mco_ruby: false
 use_mcollective: true
 user: \"peadmin\"
-enable_mutex_lock: false
 """
     it { should contain_file('webhook.yaml').with_content(content) }
   end

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -60,6 +60,10 @@ $command_prefix = $config['command_prefix'] || ''
 class Server < Sinatra::Base
 
   set :static, false
+if $config['enable_mutex_lock'] then
+  set :lock,   true
+end
+
 
   get '/' do
     raise Sinatra::NotFound


### PR DESCRIPTION
This ensures that even if webhook is triggered multiple times when r10k is
already running, it would not fail as all requests to Sinatra server are serialised.

By default, this option is set to false. To enable this:

``` Puppet
class {'r10k::webhook::config':
enable_ssl => false,
use_mcollective => false,
enable_mutex_lock => true,
}
```