### PR TITLE
create the /etc/puppetlabs/r10k directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -89,6 +89,15 @@ class r10k::config (
     validate_array($postrun)
   }
 
+  if $configfile == '/etc/puppetlabs/r10k/r10k.yaml' {
+    file {'/etc/puppetlabs/r10k':
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
+  }
+
   file { 'r10k.yaml':
     ensure  => file,
     owner   => 'root',


### PR DESCRIPTION
The /etc/puppetlabs/r10k directory is not created by any package when using the puppet 4 AIO package. This means the r10k modules will fail since it can't put the r10k.yaml file in its default location at /etc/puppetlabs/r10k/r10k.yaml .