### PR TITLE
update plugins_dir for FOSS puppet

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -133,7 +133,7 @@ class r10k::params
 
     # Mcollective configuration dynamic
     $mc_service_name = 'mcollective'
-    $plugins_dir     = '/opt/puppetlabs/mcollective/plugins'
+    $plugins_dir     = '/opt/puppetlabs/mcollective/plugins/mcollective'
     $modulepath      = undef
     $provider        = 'puppet_gem'
     $r10k_binary     = 'r10k'


### PR DESCRIPTION
For plugins to autoload correctly with a FOSS Puppet 4 install of mcollective, the directory to be managed for plugin_dir in the params.pp should be '/opt/puppetlabs/mcollective/plugins/mcollective' instead of '/opt/puppetlabs/mcollective/plugins'. Pull request incoming with proposed change.