### PR TITLE
Log when r10k not found in PATH

### DIFF
--- a/templates/agent/r10k.rb.erb
+++ b/templates/agent/r10k.rb.erb
@@ -8,6 +8,7 @@ module MCollective
          r10k_binary = `which r10k 2> /dev/null`
          if r10k_binary == ""
            #r10k not found on path.
+           Log.error('r10k binary not found in PATH')
            false
          else
            true


### PR DESCRIPTION
This will log at the 'error' level when r10k is not found in the PATH,
thus rendering the agent unusable.  Prior to this, Mcollective logging
would have to be set to 'debug', which would just return that the agent
failed to activate.  This commit hopes to provide more useful
information in this scenario.