### PR TITLE
Align webhook prefix command behavior with r10k behavior

### DIFF
--- a/files/prefix_command.rb
+++ b/files/prefix_command.rb
@@ -10,9 +10,17 @@ else
   json_data = JSON.parse(STDIN.read)
   url = json_data['repository']['url']
 
-  prefix = prefixes[:sources].each.map do |key,value|
-    key if url == value['remote']
-  end.compact
+  prefix = ""
+
+  prefixes[:sources].each do |key,value|
+    if url == value['remote'] then
+      if value['prefix'] == true
+        prefix = key
+      elsif value['prefix'].is_a? String
+        prefix = value['prefix']
+      end
+    end
+  end
 
   puts prefix
 end

--- a/spec/acceptance/prefix_webhook_spec.rb
+++ b/spec/acceptance/prefix_webhook_spec.rb
@@ -23,6 +23,15 @@ describe 'Prefix Enabled,System Ruby with No SSL, Not protected, No mcollective'
             'basedir' => '${::settings::confdir}/environments',
             'prefix'  => true,
           },
+          'noprefix' => {
+            'remote'  => 'https://github.com/noprefix/repo.git',
+            'basedir' => '${::settings::confdir}/environments'
+          },
+          'customprefix' => {
+            'remote'  => 'https://github.com/customprefix/repo.git',
+            'basedir' => '${::settings::confdir}/environments',
+            'prefix'  => 'custom'
+          }
         },
       }
       class {'r10k::webhook::config':
@@ -58,6 +67,19 @@ describe 'Prefix Enabled,System Ruby with No SSL, Not protected, No mcollective'
     it 'should calculate secteam prefix with Github payloads via payload end point' do
       shell('/usr/bin/curl -d \'{ "ref": "refs/heads/production", "repository": { "name": "puppet-control" , "url": "https://github.com/secteam/someotherrepo.git"} }\' -H "Accept: application/json" "http://localhost:8088/payload" -k -q') do |r|
         expect(r.stdout).to match(/^.*secteam_production.*$/)
+        expect(r.exit_code).to eq(0)
+      end
+    end
+    it 'should calculate custom prefix with Github payloads via payload end point' do
+      shell('/usr/bin/curl -d \'{ "ref": "refs/heads/production", "repository": { "name": "puppet-control" , "url": "https://github.com/customprefix/repo.git"} }\' -H "Accept: application/json" "http://localhost:8088/payload" -k -q') do |r|
+        expect(r.stdout).to match(/^.*custom_production.*$/)
+        expect(r.exit_code).to eq(0)
+      end
+    end
+
+    it 'should calculate no prefix Github payloads via payload end point' do
+      shell('/usr/bin/curl -d \'{ "ref": "refs/heads/production", "repository": { "name": "puppet-control" , "url": "https://github.com/noprefix/repo.git"} }\' -H "Accept: application/json" "http://localhost:8088/payload" -k -q') do |r|
+        expect(r.stdout).to match(/^.* production.*$/)
         expect(r.exit_code).to eq(0)
       end
     end


### PR DESCRIPTION
This aligns webhook prefixes behavior with the one of r10k itself. 

If prefix is set to:
- true - env is prefixed with it's name
- false (default) - env is not prefixed
- custom string - this sting is used as a prefix

See:
https://github.com/puppetlabs/r10k/doc/dynamic-environments/configuration.mkd#prefix-behaviour