### PR TITLE
postrun array requires spaces between elements

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -514,7 +514,7 @@ describe 'r10k::config' , :type => 'class' do
           :postrun           => ['/usr/bin/curl', '-F', 'deploy=done', 'http://my-app.site/endpoint'],
         }
       end
-      it { should contain_file('r10k.yaml').with_content(%r{^.*:postrun: \[\"/usr/bin/curl\",\"-F\",\"deploy=done\",\"http://my-app\.site/endpoint\"\]\n.*$}) }
+      it { should contain_file('r10k.yaml').with_content(%r{^.*:postrun: \[\"/usr/bin/curl\", \"-F\", \"deploy=done\", \"http://my-app\.site/endpoint\"\]\n.*$}) }
     end
 
     context 'with postrun left undefined' do

--- a/templates/r10k.yaml.erb
+++ b/templates/r10k.yaml.erb
@@ -1,6 +1,6 @@
 ---
 <% if @postrun and @postrun.is_a?(Array) -%>
-:postrun: [<%= @postrun.map{ |s| "\"#{s}\"" }.join(',') %>]
+:postrun: [<%= @postrun.map{ |s| "\"#{s}\"" }.join(', ') %>]
 <% end -%>
 :cachedir: <%= @cachedir %>
 <% unless @r10k_sources.empty? -%>


### PR DESCRIPTION
Without spaces between each element of the postrun: array, in r10k.yaml, a parsing error occurs
```
# cat .../r10k.pp
  class { '::r10k':
    postrun       => ['/usr/bin/curl', '-i', '--cert', "/var/lib/puppet/ssl/certs/${::ec2_instance_id}.pem", ' ....
# cat /etc/r10k.yaml 
---
:postrun: ["/usr/bin/curl","-i","--cert","/var/lib/puppet/ssl/certs/i-186e42a9.pem","--key","/var/lib/puppet/ssl/private_keys/i-186e42a9.pem","--cacert","/var/lib/puppet/ssl/ca/ca_crt.pem","-X","DELETE","https://puppet:8140/puppet-admin-api/v1/environment-cache"]
:cachedir: /var/cache/r10k
...
# puppet --version
3.8.3
]# r10k version
Faraday: you may want to install system_timer for reliable timeouts
r10k 1.5.1
# r10k deploy environment -p
Faraday: you may want to install system_timer for reliable timeouts

Error while running: #<R10K::Deployment::Config::ConfigError: Couldn't load config file: syntax error on line 1, col 262: `:postrun: ["/usr/bin/curl","-i","--cert","/var/lib/puppet/ssl/certs/i-186e42a9.pem","--key","/var/lib/puppet/ssl/private_keys/i-186e42a9.pem","--cacert","/var/lib/puppet/ssl/ca/ca_crt.pem","-X","DELETE","https://puppet:8140/puppet-admin-api/v1/environment-cache"]'>