### PR TITLE
Add option to lowercase environment names

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,6 +51,7 @@ class r10k::params
   $webhook_r10k_command_prefix   = 'umask 0022;' # 'sudo' is the canonical example for this
   $webhook_repository_events     = undef
   $webhook_enable_mutex_lock     = false
+  $webhook_allow_uppercase       = true          # for backwards compatibility. Default to off on a major semver update.
 
   if $::osfamily == 'Debian' {
     $functions_path     = '/lib/lsb/init-functions'

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -30,6 +30,7 @@ class r10k::webhook::config (
   $yaml_template         = $r10k::params::webhook_yaml_template,
   $command_prefix        = $r10k::params::webhook_r10k_command_prefix,
   $repository_events     = $r10k::params::webhook_repository_events,
+  $allow_uppercase       = $r10k::params::webhook_allow_uppercase,
   $configfile            = '/etc/webhook.yaml',
   $manage_symlink        = false,
   $configfile_symlink    = '/etc/webhook.yaml',
@@ -62,6 +63,7 @@ class r10k::webhook::config (
       'command_prefix'        => $command_prefix,
       'repository_events'     => $repository_events,
       'enable_mutex_lock'     => $enable_mutex_lock,
+      'allow_uppercase'       => $allow_uppercase,
     }
   } else {
     validate_hash($hash)

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -22,6 +22,7 @@ describe 'r10k::webhook::config' , :type => 'class' do
 
     content = """---
 access_logfile: \"/var/log/webhook/access.log\"
+allow_uppercase: true
 bind_address: \"0.0.0.0\"
 certname: \"peadmin\"
 certpath: \"/var/lib/peadmin/.mcollective.d\"
@@ -67,6 +68,7 @@ user: \"peadmin\"
 
     content = """---
 access_logfile: \"/var/log/webhook/access.log\"
+allow_uppercase: true
 bind_address: \"0.0.0.0\"
 client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
@@ -114,6 +116,7 @@ user: \"puppet\"
 
     content = """---
 access_logfile: \"/var/log/webhook/access.log\"
+allow_uppercase: true
 bind_address: \"0.0.0.0\"
 client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
@@ -162,6 +165,7 @@ user: \"puppet\"
 
     content = """---
 access_logfile: \"/var/log/webhook/access.log\"
+allow_uppercase: true
 bind_address: \"0.0.0.0\"
 client_cfg: \"/var/lib/peadmin/.mcollective\"
 client_timeout: \"120\"
@@ -210,6 +214,7 @@ user: \"puppet\"
 
     content = """---
 access_logfile: \"/var/log/webhook/access.log\"
+allow_uppercase: true
 bind_address: \"0.0.0.0\"
 certname: \"peadmin\"
 certpath: \"/var/lib/peadmin/.mcollective.d\"

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -152,9 +152,9 @@ end
     # The best we can do is just deploy all environments by passing nil to
     # deploy() if we don't know the correct branch.
     if prefix.nil? or prefix.empty? or branch.nil? or branch.empty?
-      deploy(branch)
+      deploy(normalize(branch))
     else
-      deploy("#{prefix}_#{branch}")
+      deploy(normalize("#{prefix}_#{branch}"))
     end
 
   end
@@ -267,6 +267,11 @@ end
     def repo_user(data)
       # Tested with GitHub only
       data['repository']['owner']['login'] rescue nil
+    end
+
+    def normalize(str)
+      # one could argue that r10k should do this along with the other normalization it does...
+      $config['allow_uppercase'] ? str : str.downcase
     end
 
     def run_prefix_command(payload)


### PR DESCRIPTION
According to
https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html#environments,
environment names can only include lowercase characters *. As such,
downcase the environment we're trying to deploy, otherwise parts of the
PE stack can get quite cranky with you. This is a major change, though, so
default to the old behaviour of allowing uppercase names through.

* Empirically validated. The Puppet Master can handle uppercased
  environment names, but the Console (maybe other components as well)
  cannot. That means that the Console will assign the downcased
  environment name, which doesn't actually exist on disk :-/