### PR TITLE
Support for TFS/Visual Studio Git

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -133,6 +133,7 @@ end
         data['ref']                                          ||  # github & gitlab
         data['refChanges'][0]['refId']            rescue nil ||  # stash
         data['push']['changes'][0]['new']['name'] rescue nil ||  # bitbucket
+        data['resource']['refUpdates'][0]['name'] rescue nil ||  # TFS/VisualStudio-Git
         data['repository']['default_branch']                     # github tagged release; no ref.
       ).sub('refs/heads/', '') rescue nil
 


### PR DESCRIPTION
This commit adds support for the Git repo option of Microsoft Team Foundation Server (TFS) or Visual Studio Online. To use it, create a webhook in TFS that has "Resource details to send" set to "All". The JSON structure is distinct from Github/Gitlab/Stash/Bitbucket, thus the need for this commit.